### PR TITLE
feat(toasts): add link to transfer log

### DIFF
--- a/src/__tests__/utils/object.spec.js
+++ b/src/__tests__/utils/object.spec.js
@@ -1,23 +1,19 @@
 import {findIndexById} from '../../utils';
 
 describe('findIndexById', () => {
-  it("gets array of objects, returns the matching-object's index (Number), accourding it's 'id'.", () => {
+  it("should return the matching-object's index (Number), accourding it's 'id'.", () => {
     const array = [{id: '0cbff33f'}, {id: '11a083e3'}];
     const resultIndex = findIndexById(array, '0cbff33f');
     expect(resultIndex).toEqual(0);
-    // since index 0 is a legit result, we need this condition to handle the result:
-    expect((!!resultIndex || resultIndex === 0) && resultIndex > -1).toBeTruthy();
   });
 
-  it('if no matching object, returns -1', () => {
+  it('should return -1 if no matching object', () => {
     const array = [{id: '0cbff33f'}, {id: '11a083e3'}];
     const resultIndex = findIndexById(array, '153w9f6e');
     expect(resultIndex).toEqual(-1);
-    // handling properly the result, so when -1 it's falsy:
-    expect((!!resultIndex || resultIndex === 0) && resultIndex > -1).toBeFalsy();
   });
 
-  it("returns -1(Number) for falsy 'array' or falsy 'id', but allows 'id' to be 0 or '0'", () => {
+  it("returns -1 (Number) for falsy 'array' or falsy 'id', but allows 'id' to be 0 or '0'", () => {
     const array = [{id: '0cbff33f'}, {id: '0'}, {id: 0}];
     expect(findIndexById(undefined, '0cbff33f')).toEqual(-1);
     expect(findIndexById([], '0cbff33f')).toEqual(-1);

--- a/src/__tests__/utils/object.spec.js
+++ b/src/__tests__/utils/object.spec.js
@@ -13,7 +13,7 @@ describe('findIndexById', () => {
     expect(resultIndex).toEqual(-1);
   });
 
-  it("returns -1 (Number) for falsy 'array' or falsy 'id', but allows 'id' to be 0 or '0'", () => {
+  it("should return -1 (Number) for falsy 'array' or falsy 'id', but allows 'id' to be 0 or '0'", () => {
     const array = [{id: '0cbff33f'}, {id: '0'}, {id: 0}];
     expect(findIndexById(undefined, '0cbff33f')).toEqual(-1);
     expect(findIndexById([], '0cbff33f')).toEqual(-1);

--- a/src/__tests__/utils/object.spec.js
+++ b/src/__tests__/utils/object.spec.js
@@ -13,9 +13,8 @@ describe('findIndexById', () => {
     expect(resultIndex).toEqual(-1);
   });
 
-  it("should return -1 (Number) for falsy 'array' or falsy 'id', but allows 'id' to be 0 or '0'", () => {
+  it("should return -1 (Number) for empty 'array' or falsy 'id', but allows 'id' to be 0 or '0'", () => {
     const array = [{id: '0cbff33f'}, {id: '0'}, {id: 0}];
-    expect(findIndexById(undefined, '0cbff33f')).toEqual(-1);
     expect(findIndexById([], '0cbff33f')).toEqual(-1);
     expect(findIndexById(array, undefined)).toEqual(-1);
     expect(findIndexById(array, null)).toEqual(-1);

--- a/src/__tests__/utils/object.spec.js
+++ b/src/__tests__/utils/object.spec.js
@@ -6,12 +6,15 @@ describe('findIndexById', () => {
     const resultIndex = findIndexById(array, '0cbff33f');
     expect(resultIndex).toEqual(0);
     // since index 0 is a legit result, we need this condition to handle the result:
-    expect(!!resultIndex || (0 === 0 && resultIndex > -1)).toBeTruthy();
+    expect((!!resultIndex || resultIndex === 0) && resultIndex > -1).toBeTruthy();
   });
 
   it('if no matching object, returns -1', () => {
     const array = [{id: '0cbff33f'}, {id: '11a083e3'}];
-    expect(findIndexById(array, '153w9f6e')).toEqual(-1);
+    const resultIndex = findIndexById(array, '153w9f6e');
+    expect(resultIndex).toEqual(-1);
+    // handling properly the result, so when -1 it's falsy:
+    expect((!!resultIndex || resultIndex === 0) && resultIndex > -1).toBeFalsy();
   });
 
   it("returns -1(Number) for falsy 'array' or falsy 'id', but allows 'id' to be 0 or '0'", () => {
@@ -19,6 +22,7 @@ describe('findIndexById', () => {
     expect(findIndexById(undefined, '0cbff33f')).toEqual(-1);
     expect(findIndexById([], '0cbff33f')).toEqual(-1);
     expect(findIndexById(array, undefined)).toEqual(-1);
+    expect(findIndexById(array, null)).toEqual(-1);
     expect(findIndexById(array, '0')).toEqual(1);
     expect(findIndexById(array, 0)).toEqual(2);
   });

--- a/src/__tests__/utils/object.spec.js
+++ b/src/__tests__/utils/object.spec.js
@@ -1,0 +1,25 @@
+import {findIndexById} from '../../utils';
+
+describe('findIndexById', () => {
+  it("gets array of objects, returns the matching-object's index (Number), accourding it's 'id'.", () => {
+    const array = [{id: '0cbff33f'}, {id: '11a083e3'}];
+    const resultIndex = findIndexById(array, '0cbff33f');
+    expect(resultIndex).toEqual(0);
+    // since index 0 is a legit result, we need this condition to handle the result:
+    expect(!!resultIndex || (0 === 0 && resultIndex > -1)).toBeTruthy();
+  });
+
+  it('if no matching object, returns -1', () => {
+    const array = [{id: '0cbff33f'}, {id: '11a083e3'}];
+    expect(findIndexById(array, '153w9f6e')).toEqual(-1);
+  });
+
+  it("returns -1(Number) for falsy 'array' or falsy 'id', but allows 'id' to be 0 or '0'", () => {
+    const array = [{id: '0cbff33f'}, {id: '0'}, {id: 0}];
+    expect(findIndexById(undefined, '0cbff33f')).toEqual(-1);
+    expect(findIndexById([], '0cbff33f')).toEqual(-1);
+    expect(findIndexById(array, undefined)).toEqual(-1);
+    expect(findIndexById(array, '0')).toEqual(1);
+    expect(findIndexById(array, 0)).toEqual(2);
+  });
+});

--- a/src/components/Features/Account/Account.js
+++ b/src/components/Features/Account/Account.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 
 import {LINKS} from '../../../constants';
 import {useCompleteTransferToL1} from '../../../hooks';
@@ -27,7 +27,6 @@ export const Account = ({transferId}) => {
   const transfers = useAccountTransfers(account);
   const {isL1, isL2, fromNetwork} = useTransferData();
   const completeTransferToL1 = useCompleteTransferToL1();
-  const [expandTransferLog, setExpandTransferLog] = useState(false);
 
   const renderTransfers = () => {
     return transfers.length
@@ -40,15 +39,6 @@ export const Account = ({transferId}) => {
         ))
       : null;
   };
-
-  useEffect(() => {
-    if (transferId) {
-      const index = findIndexById(transfers, transferId);
-      setExpandTransferLog((!!index || index === 0) && index > -1);
-    } else {
-      setExpandTransferLog(false);
-    }
-  }, [transferId]);
 
   return (
     <Menu>
@@ -65,7 +55,7 @@ export const Account = ({transferId}) => {
         {isL2 && (
           <LinkButton text={LINKS.VOYAGER.text} url={LINKS.VOYAGER.accountUrl(chainId, account)} />
         )}
-        <TransferLogContainer expanded={expandTransferLog}>
+        <TransferLogContainer transferIndex={findIndexById(transfers, transferId)}>
           {renderTransfers()}
         </TransferLogContainer>
         <LogoutButton isDisabled={isL2} onClick={resetWallet} />

--- a/src/components/Features/Account/Account.js
+++ b/src/components/Features/Account/Account.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {LINKS} from '../../../constants';
 import {useCompleteTransferToL1} from '../../../hooks';
@@ -27,6 +27,7 @@ export const Account = ({transferId}) => {
   const transfers = useAccountTransfers(account);
   const {isL1, isL2, fromNetwork} = useTransferData();
   const completeTransferToL1 = useCompleteTransferToL1();
+  const [expandTransferLog, setExpandTransferLog] = useState(false);
 
   const renderTransfers = () => {
     return transfers.length
@@ -39,6 +40,15 @@ export const Account = ({transferId}) => {
         ))
       : null;
   };
+
+  useEffect(() => {
+    if (transferId) {
+      const index = findIndexById(transfers, transferId);
+      setExpandTransferLog((!!index || index === 0) && index > -1);
+    } else {
+      setExpandTransferLog(false);
+    }
+  }, [transferId]);
 
   return (
     <Menu>
@@ -55,7 +65,7 @@ export const Account = ({transferId}) => {
         {isL2 && (
           <LinkButton text={LINKS.VOYAGER.text} url={LINKS.VOYAGER.accountUrl(chainId, account)} />
         )}
-        <TransferLogContainer transferIndex={findIndexById(transfers, transferId)}>
+        <TransferLogContainer expanded={expandTransferLog}>
           {renderTransfers()}
         </TransferLogContainer>
         <LogoutButton isDisabled={isL2} onClick={resetWallet} />

--- a/src/components/Features/Account/Account.js
+++ b/src/components/Features/Account/Account.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
-import React, {useState, useEffect} from 'react';
+import React from 'react';
 
 import {LINKS} from '../../../constants';
 import {useCompleteTransferToL1} from '../../../hooks';
 import {useAccountTransfers} from '../../../providers/TransfersProvider';
 import {useWallets} from '../../../providers/WalletsProvider';
+import {findIndexById} from '../../../utils';
 import {
   AccountAddress,
   BackButton,
@@ -20,14 +21,12 @@ import {TransferLog} from '../TransferLog/TransferLog';
 import styles from './Account.module.scss';
 import {TITLE_TXT} from './Account.strings';
 
-export const Account = menuProps => {
+export const Account = ({transferId}) => {
   const {showTransferMenu} = useBridgeActions();
   const {account, chainId, resetWallet} = useWallets();
   const transfers = useAccountTransfers(account);
   const {isL1, isL2, fromNetwork} = useTransferData();
   const completeTransferToL1 = useCompleteTransferToL1();
-  const {transferId} = menuProps;
-  const [highlightedIndex, setHighlightedIndex] = useState(null);
 
   const renderTransfers = () => {
     return transfers.length
@@ -40,17 +39,6 @@ export const Account = menuProps => {
         ))
       : null;
   };
-
-  const findIndexById = (array, id) => {
-    return array.findIndex(item => item.id === id);
-  };
-
-  useEffect(() => {
-    if (transferId) {
-      const highlightedIndex = findIndexById(transfers, transferId);
-      highlightedIndex ? setHighlightedIndex(highlightedIndex) : '';
-    }
-  }, [transferId]);
 
   return (
     <Menu>
@@ -67,7 +55,7 @@ export const Account = menuProps => {
         {isL2 && (
           <LinkButton text={LINKS.VOYAGER.text} url={LINKS.VOYAGER.accountUrl(chainId, account)} />
         )}
-        <TransferLogContainer highlighted={highlightedIndex}>
+        <TransferLogContainer transferIndex={findIndexById(transfers, transferId)}>
           {renderTransfers()}
         </TransferLogContainer>
         <LogoutButton isDisabled={isL2} onClick={resetWallet} />
@@ -77,5 +65,5 @@ export const Account = menuProps => {
 };
 
 Account.propTypes = {
-  menuProps: PropTypes.object
+  transferId: PropTypes.string
 };

--- a/src/components/Features/Account/Account.js
+++ b/src/components/Features/Account/Account.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import PropTypes from 'prop-types';
+import React, {useState, useEffect} from 'react';
 
 import {LINKS} from '../../../constants';
 import {useCompleteTransferToL1} from '../../../hooks';
@@ -19,12 +20,14 @@ import {TransferLog} from '../TransferLog/TransferLog';
 import styles from './Account.module.scss';
 import {TITLE_TXT} from './Account.strings';
 
-export const Account = () => {
+export const Account = menuProps => {
   const {showTransferMenu} = useBridgeActions();
   const {account, chainId, resetWallet} = useWallets();
   const transfers = useAccountTransfers(account);
   const {isL1, isL2, fromNetwork} = useTransferData();
   const completeTransferToL1 = useCompleteTransferToL1();
+  const {transferId} = menuProps;
+  const [highlightedIndex, setHighlightedIndex] = useState(null);
 
   const renderTransfers = () => {
     return transfers.length
@@ -37,6 +40,17 @@ export const Account = () => {
         ))
       : null;
   };
+
+  const findIndexById = (array, id) => {
+    return array.findIndex(item => item.id === id);
+  };
+
+  useEffect(() => {
+    if (transferId) {
+      const highlightedIndex = findIndexById(transfers, transferId);
+      highlightedIndex ? setHighlightedIndex(highlightedIndex) : '';
+    }
+  }, [transferId]);
 
   return (
     <Menu>
@@ -53,9 +67,15 @@ export const Account = () => {
         {isL2 && (
           <LinkButton text={LINKS.VOYAGER.text} url={LINKS.VOYAGER.accountUrl(chainId, account)} />
         )}
-        <TransferLogContainer>{renderTransfers()}</TransferLogContainer>
+        <TransferLogContainer highlighted={highlightedIndex}>
+          {renderTransfers()}
+        </TransferLogContainer>
         <LogoutButton isDisabled={isL2} onClick={resetWallet} />
       </div>
     </Menu>
   );
+};
+
+Account.propTypes = {
+  menuProps: PropTypes.object
 };

--- a/src/components/Features/Bridge/Bridge.hooks.js
+++ b/src/components/Features/Bridge/Bridge.hooks.js
@@ -9,15 +9,20 @@ export const useBridgeData = () => ({
   ...useSelector(selectBridge)
 });
 
-export const useBridgeActions = () => ({
-  showAccountMenu: useShowBridgeMenu(MenuType.ACCOUNT),
-  showTransferMenu: useShowBridgeMenu(MenuType.TRANSFER),
-  showSelectTokenMenu: useShowBridgeMenu(MenuType.SELECT_TOKEN)
-});
+export const useBridgeActions = menuProps => {
+  return {
+    showAccountMenu: useShowBridgeMenu(MenuType.ACCOUNT, menuProps),
+    showTransferMenu: useShowBridgeMenu(MenuType.TRANSFER),
+    showSelectTokenMenu: useShowBridgeMenu(MenuType.SELECT_TOKEN)
+  };
+};
 
 const useShowBridgeMenu = type => {
   const dispatch = useDispatch();
-  return useCallback(() => {
-    dispatch(showMenuAction(type));
-  }, [dispatch]);
+  return useCallback(
+    menuProps => {
+      dispatch(showMenuAction({type, menuProps}));
+    },
+    [dispatch]
+  );
 };

--- a/src/components/Features/Bridge/Bridge.hooks.js
+++ b/src/components/Features/Bridge/Bridge.hooks.js
@@ -3,7 +3,7 @@ import {useDispatch, useSelector} from 'react-redux';
 
 import {MenuType} from '../../../enums';
 import {selectBridge} from './Bridge.selectors';
-import {showMenuAction} from './Bridge.slice';
+import {showMenuAction, resetMenuPropsAction} from './Bridge.slice';
 
 export const useBridgeData = () => ({
   ...useSelector(selectBridge)
@@ -13,7 +13,8 @@ export const useBridgeActions = () => {
   return {
     showAccountMenu: useShowBridgeMenu(MenuType.ACCOUNT),
     showTransferMenu: useShowBridgeMenu(MenuType.TRANSFER),
-    showSelectTokenMenu: useShowBridgeMenu(MenuType.SELECT_TOKEN)
+    showSelectTokenMenu: useShowBridgeMenu(MenuType.SELECT_TOKEN),
+    resetMenuProps: useResetMenuProps()
   };
 };
 
@@ -25,4 +26,11 @@ const useShowBridgeMenu = menu => {
     },
     [dispatch]
   );
+};
+
+const useResetMenuProps = () => {
+  const dispatch = useDispatch();
+  return useCallback(() => {
+    dispatch(resetMenuPropsAction());
+  }, [dispatch]);
 };

--- a/src/components/Features/Bridge/Bridge.hooks.js
+++ b/src/components/Features/Bridge/Bridge.hooks.js
@@ -9,19 +9,19 @@ export const useBridgeData = () => ({
   ...useSelector(selectBridge)
 });
 
-export const useBridgeActions = menuProps => {
+export const useBridgeActions = () => {
   return {
-    showAccountMenu: useShowBridgeMenu(MenuType.ACCOUNT, menuProps),
+    showAccountMenu: useShowBridgeMenu(MenuType.ACCOUNT),
     showTransferMenu: useShowBridgeMenu(MenuType.TRANSFER),
     showSelectTokenMenu: useShowBridgeMenu(MenuType.SELECT_TOKEN)
   };
 };
 
-const useShowBridgeMenu = type => {
+const useShowBridgeMenu = menu => {
   const dispatch = useDispatch();
   return useCallback(
     menuProps => {
-      dispatch(showMenuAction({type, menuProps}));
+      dispatch(showMenuAction({menu, menuProps}));
     },
     [dispatch]
   );

--- a/src/components/Features/Bridge/Bridge.js
+++ b/src/components/Features/Bridge/Bridge.js
@@ -15,7 +15,7 @@ export const Bridge = () => {
       case MenuType.SELECT_TOKEN:
         return <SelectToken />;
       case MenuType.ACCOUNT:
-        return <Account {...menuProps} />;
+        return <Account {...menuProps[MenuType.ACCOUNT]} />;
     }
   };
 

--- a/src/components/Features/Bridge/Bridge.js
+++ b/src/components/Features/Bridge/Bridge.js
@@ -6,7 +6,7 @@ import {useBridgeData} from './Bridge.hooks';
 import styles from './Bridge.module.scss';
 
 export const Bridge = () => {
-  const {menu} = useBridgeData();
+  const {menu, menuProps} = useBridgeData();
 
   const renderMenu = () => {
     switch (menu) {
@@ -15,7 +15,7 @@ export const Bridge = () => {
       case MenuType.SELECT_TOKEN:
         return <SelectToken />;
       case MenuType.ACCOUNT:
-        return <Account />;
+        return <Account {...menuProps} />;
     }
   };
 

--- a/src/components/Features/Bridge/Bridge.slice.js
+++ b/src/components/Features/Bridge/Bridge.slice.js
@@ -15,7 +15,9 @@ const bridgeSlice = createSlice({
   reducers: {
     showMenuAction(state, action) {
       state.menu = action.payload.menu;
-      Object.assign(state.menuProps, initialState.menuProps, action.payload.menuProps);
+      state.menuProps = {
+        [action.payload.menu]: action.payload.menuProps
+      };
     },
     resetMenuPropsAction(state) {
       state.menuProps[state.menu] = initialState.menuProps[state.menu];

--- a/src/components/Features/Bridge/Bridge.slice.js
+++ b/src/components/Features/Bridge/Bridge.slice.js
@@ -4,7 +4,9 @@ import {MenuType} from '../../../enums';
 
 const initialState = {
   menu: MenuType.TRANSFER,
-  menuProps: null
+  menuProps: {
+    transferId: null
+  }
 };
 
 const bridgeSlice = createSlice({
@@ -13,7 +15,13 @@ const bridgeSlice = createSlice({
   reducers: {
     showMenuAction(state, action) {
       state.menu = action.payload.menu;
-      state.menuProps = action.payload.menuProps;
+      if (!action.payload.menuProps || !action.payload.menuProps.transferId) {
+        state.menuProps = {
+          transferId: null
+        };
+      } else {
+        state.menuProps = action.payload.menuProps;
+      }
     }
   }
 });

--- a/src/components/Features/Bridge/Bridge.slice.js
+++ b/src/components/Features/Bridge/Bridge.slice.js
@@ -5,7 +5,7 @@ import {MenuType} from '../../../enums';
 const initialState = {
   menu: MenuType.TRANSFER,
   menuProps: {
-    transferId: null
+    [MenuType.ACCOUNT]: {transferId: null}
   }
 };
 
@@ -16,10 +16,13 @@ const bridgeSlice = createSlice({
     showMenuAction(state, action) {
       state.menu = action.payload.menu;
       Object.assign(state.menuProps, initialState.menuProps, action.payload.menuProps);
+    },
+    resetMenuPropsAction(state) {
+      state.menuProps[state.menu] = initialState.menuProps[state.menu];
     }
   }
 });
 
-export const {showMenuAction, resetAction} = bridgeSlice.actions;
+export const {showMenuAction, resetAction, resetMenuPropsAction} = bridgeSlice.actions;
 
 export default bridgeSlice.reducer;

--- a/src/components/Features/Bridge/Bridge.slice.js
+++ b/src/components/Features/Bridge/Bridge.slice.js
@@ -3,7 +3,8 @@ import {createSlice} from '@reduxjs/toolkit';
 import {MenuType} from '../../../enums';
 
 const initialState = {
-  menu: MenuType.TRANSFER
+  menu: MenuType.TRANSFER,
+  menuProps: null
 };
 
 const bridgeSlice = createSlice({
@@ -11,7 +12,8 @@ const bridgeSlice = createSlice({
   initialState,
   reducers: {
     showMenuAction(state, action) {
-      state.menu = action.payload;
+      state.menu = action.payload.type;
+      state.menuProps = action.payload.menuProps;
     }
   }
 });

--- a/src/components/Features/Bridge/Bridge.slice.js
+++ b/src/components/Features/Bridge/Bridge.slice.js
@@ -20,6 +20,6 @@ const bridgeSlice = createSlice({
   }
 });
 
-export const {showMenuAction, resetAction, resetFocusedTransfer} = bridgeSlice.actions;
+export const {showMenuAction, resetAction} = bridgeSlice.actions;
 
 export default bridgeSlice.reducer;

--- a/src/components/Features/Bridge/Bridge.slice.js
+++ b/src/components/Features/Bridge/Bridge.slice.js
@@ -15,17 +15,11 @@ const bridgeSlice = createSlice({
   reducers: {
     showMenuAction(state, action) {
       state.menu = action.payload.menu;
-      if (!action.payload.menuProps || !action.payload.menuProps.transferId) {
-        state.menuProps = {
-          transferId: null
-        };
-      } else {
-        state.menuProps = action.payload.menuProps;
-      }
+      Object.assign(state.menuProps, initialState.menuProps, action.payload.menuProps);
     }
   }
 });
 
-export const {showMenuAction, resetAction} = bridgeSlice.actions;
+export const {showMenuAction, resetAction, resetFocusedTransfer} = bridgeSlice.actions;
 
 export default bridgeSlice.reducer;

--- a/src/components/Features/Bridge/Bridge.slice.js
+++ b/src/components/Features/Bridge/Bridge.slice.js
@@ -12,7 +12,7 @@ const bridgeSlice = createSlice({
   initialState,
   reducers: {
     showMenuAction(state, action) {
-      state.menu = action.payload.type;
+      state.menu = action.payload.menu;
       state.menuProps = action.payload.menuProps;
     }
   }

--- a/src/components/Features/ToastProvider/ToastProvider.js
+++ b/src/components/Features/ToastProvider/ToastProvider.js
@@ -135,7 +135,7 @@ export const ToastProvider = () => {
   };
 
   const goToTransferLog = transfer => {
-    transfer.type === ActionType.TRANSFER_TO_L2 ? swapToL2() : swapToL1();
+    transfer.type === ActionType.TRANSFER_TO_L2 ? swapToL1() : swapToL2();
     showAccountMenu({transferId: transfer.id});
   };
 

--- a/src/components/Features/ToastProvider/ToastProvider.js
+++ b/src/components/Features/ToastProvider/ToastProvider.js
@@ -9,7 +9,6 @@ import {
   isOnChain,
   isPending,
   isRejected,
-  MenuType,
   NetworkType
 } from '../../../enums';
 import {useCompleteTransferToL1, usePrevious} from '../../../hooks';
@@ -137,7 +136,7 @@ export const ToastProvider = () => {
 
   const goToTransferLog = transfer => {
     transfer.type === ActionType.TRANSFER_TO_L2 ? swapToL1() : swapToL2();
-    showAccountMenu({[MenuType.ACCOUNT]: {transferId: transfer.id}});
+    showAccountMenu({transferId: transfer.id});
   };
 
   return (

--- a/src/components/Features/ToastProvider/ToastProvider.js
+++ b/src/components/Features/ToastProvider/ToastProvider.js
@@ -104,7 +104,7 @@ export const ToastProvider = () => {
       isLoading={isLoading}
       transfer={transfer}
       onClose={() => dismissToast(transfer)}
-      onTransferLogLink={() => goToTransferLog(transfer)}
+      onTransferLogLinkClick={() => goToTransferLog(transfer)}
     />
   );
 
@@ -115,7 +115,7 @@ export const ToastProvider = () => {
       onClose={() => dismissToast(transfer)}
       onCompleteTransfer={() => onCompleteTransferClick(transfer)}
       onDismiss={() => dismissToast(transfer)}
-      onTransferLogLink={() => goToTransferLog(transfer)}
+      onTransferLogLinkClick={() => goToTransferLog(transfer)}
     />
   );
 

--- a/src/components/Features/ToastProvider/ToastProvider.js
+++ b/src/components/Features/ToastProvider/ToastProvider.js
@@ -9,6 +9,7 @@ import {
   isOnChain,
   isPending,
   isRejected,
+  MenuType,
   NetworkType
 } from '../../../enums';
 import {useCompleteTransferToL1, usePrevious} from '../../../hooks';
@@ -136,7 +137,7 @@ export const ToastProvider = () => {
 
   const goToTransferLog = transfer => {
     transfer.type === ActionType.TRANSFER_TO_L2 ? swapToL1() : swapToL2();
-    showAccountMenu({transferId: transfer.id});
+    showAccountMenu({[MenuType.ACCOUNT]: {transferId: transfer.id}});
   };
 
   return (

--- a/src/components/Features/ToastProvider/ToastProvider.js
+++ b/src/components/Features/ToastProvider/ToastProvider.js
@@ -14,6 +14,8 @@ import {
 import {useCompleteTransferToL1, usePrevious} from '../../../hooks';
 import {useTransfers} from '../../../providers/TransfersProvider';
 import {getFullTime} from '../../../utils';
+import {useBridgeActions} from '../../Features/Bridge/Bridge.hooks';
+import {useIsL1, useIsL2} from '../../Features/Transfer/Transfer.hooks';
 import {ToastBody, TransferToast, CompleteTransferToL1Toast} from '../../UI';
 import styles from './ToastProvider.module.scss';
 import {ALPHA_DISCLAIMER_MSG} from './ToastProvider.strings';
@@ -24,6 +26,9 @@ export const ToastProvider = () => {
   const toastsMap = useRef({});
   const toastsDismissed = useRef({});
   const completeTransferToL1 = useCompleteTransferToL1();
+  const {showAccountMenu} = useBridgeActions();
+  const [, swapToL1] = useIsL1();
+  const [, swapToL2] = useIsL2();
 
   useEffect(() => {
     showAlphaDisclaimerToast();
@@ -99,6 +104,7 @@ export const ToastProvider = () => {
       isLoading={isLoading}
       transfer={transfer}
       onClose={() => dismissToast(transfer)}
+      onTransferLogLink={() => goToTransferLog(transfer)}
     />
   );
 
@@ -109,6 +115,7 @@ export const ToastProvider = () => {
       onClose={() => dismissToast(transfer)}
       onCompleteTransfer={() => onCompleteTransferClick(transfer)}
       onDismiss={() => dismissToast(transfer)}
+      onTransferLogLink={() => goToTransferLog(transfer)}
     />
   );
 
@@ -125,6 +132,11 @@ export const ToastProvider = () => {
   const onCompleteTransferClick = async transfer => {
     await completeTransferToL1(transfer);
     dismissToast(transfer);
+  };
+
+  const goToTransferLog = transfer => {
+    transfer.type === ActionType.TRANSFER_TO_L2 ? swapToL2() : swapToL1();
+    showAccountMenu({transferId: transfer.id});
   };
 
   return (

--- a/src/components/Features/TransferLog/TransferLog.module.scss
+++ b/src/components/Features/TransferLog/TransferLog.module.scss
@@ -15,16 +15,6 @@ $marker-color: $--color-beta-1;
   padding-left: 5px;
   position: relative;
 
-  &::before {
-    content: '';
-    display: block;
-    position: absolute;
-    left: -11px;
-    width: 6px;
-    height: 70px;
-    background-color: $marker-color;
-  }
-
   &:nth-child(2) {
     margin-top: 20px;
   }

--- a/src/components/Features/TransferLog/TransferLog.module.scss
+++ b/src/components/Features/TransferLog/TransferLog.module.scss
@@ -3,6 +3,7 @@
 $color: $--color-alpha-6;
 $hr-color: $--color-alpha-3;
 $error-color: $--color-error;
+$marker-color: $--color-beta-1;
 
 .transferLog {
   display: flex;
@@ -11,6 +12,18 @@ $error-color: $--color-error;
   font-size: 15px;
   line-height: 21px;
   margin: 10px 5px;
+  padding-left: 5px;
+  position: relative;
+
+  &::before {
+    content: '';
+    display: block;
+    position: absolute;
+    left: -11px;
+    width: 6px;
+    height: 70px;
+    background-color: $marker-color;
+  }
 
   &:nth-child(2) {
     margin-top: 20px;
@@ -55,4 +68,8 @@ hr {
     display: block;
     border: 1px solid $hr-color;
   }
+}
+
+.markered-transfer {
+  background-color: $marker-color;
 }

--- a/src/components/UI/Toast/CompleteTransferToL1Toast/CompleteTransferToL1Toast.js
+++ b/src/components/UI/Toast/CompleteTransferToL1Toast/CompleteTransferToL1Toast.js
@@ -7,6 +7,7 @@ import {useColors} from '../../../../hooks';
 import {TransferData} from '../../../Features';
 import {ToastBody} from '../ToastBody/ToastBody';
 import {ToastButton, ToastButtons} from '../ToastButton/ToastButton';
+import {ToastFooter, TransferLogLink} from '../ToastFooter/ToastFooter';
 import {ToastHeader} from '../ToastHeader/ToastHeader';
 import {ToastSeparator} from '../ToastSeparator/ToastSeparator';
 import styles from './CompleteTransferToL1Toast.module.scss';
@@ -22,6 +23,7 @@ export const CompleteTransferToL1Toast = ({
   transfer,
   onDismiss,
   onCompleteTransfer,
+  onTransferLogLink,
   onClose
 }) => {
   const {colorBeta, colorOmega1} = useColors();
@@ -54,6 +56,9 @@ export const CompleteTransferToL1Toast = ({
             </ToastButtons>
             <ToastSeparator />
             <TransferData style={{fontSize: '10px'}} transfer={transfer} />
+            <ToastFooter>
+              <TransferLogLink onClick={onTransferLogLink} />
+            </ToastFooter>
           </div>
         </div>
       </div>
@@ -66,5 +71,6 @@ CompleteTransferToL1Toast.propTypes = {
   transfer: PropTypes.object,
   onDismiss: PropTypes.func,
   onCompleteTransfer: PropTypes.func,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  onTransferLogLink: PropTypes.func
 };

--- a/src/components/UI/Toast/CompleteTransferToL1Toast/CompleteTransferToL1Toast.js
+++ b/src/components/UI/Toast/CompleteTransferToL1Toast/CompleteTransferToL1Toast.js
@@ -23,7 +23,7 @@ export const CompleteTransferToL1Toast = ({
   transfer,
   onDismiss,
   onCompleteTransfer,
-  onTransferLogLink,
+  onTransferLogLinkClick,
   onClose
 }) => {
   const {colorBeta, colorOmega1} = useColors();
@@ -57,7 +57,7 @@ export const CompleteTransferToL1Toast = ({
             <ToastSeparator />
             <TransferData style={{fontSize: '10px'}} transfer={transfer} />
             <ToastFooter>
-              <TransferLogLink onClick={onTransferLogLink} />
+              <TransferLogLink onClick={onTransferLogLinkClick} />
             </ToastFooter>
           </div>
         </div>
@@ -72,5 +72,5 @@ CompleteTransferToL1Toast.propTypes = {
   onDismiss: PropTypes.func,
   onCompleteTransfer: PropTypes.func,
   onClose: PropTypes.func,
-  onTransferLogLink: PropTypes.func
+  onTransferLogLinkClick: PropTypes.func
 };

--- a/src/components/UI/Toast/ToastFooter/ToastFooter.js
+++ b/src/components/UI/Toast/ToastFooter/ToastFooter.js
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import styles from './ToastFooter.module.scss';
+import {TRANSFER_LOG_LINK_BTN_TXT} from './ToastFooter.strings';
+
+export const ToastFooter = ({children}) => {
+  return <div className={styles.toastFooter}>{children}</div>;
+};
+
+export const TransferLogLink = ({onClick}) => {
+  return (
+    <div className={styles.transferLogLink} onClick={onClick}>
+      {TRANSFER_LOG_LINK_BTN_TXT}
+    </div>
+  );
+};
+
+ToastFooter.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
+};
+
+TransferLogLink.propTypes = {
+  text: PropTypes.string,
+  onClick: PropTypes.func
+};

--- a/src/components/UI/Toast/ToastFooter/ToastFooter.module.scss
+++ b/src/components/UI/Toast/ToastFooter/ToastFooter.module.scss
@@ -5,6 +5,8 @@ $colorHover: $--color-omega-1;
 
 .toastFooter {
   margin-bottom: 5px;
+  display: flex;
+  flex-flow: column nowrap;
 }
 
 .transferLogLink {
@@ -14,4 +16,5 @@ $colorHover: $--color-omega-1;
   color: $color;
   width: 114px;
   text-decoration: underline;
+  align-self: flex-end;
 }

--- a/src/components/UI/Toast/ToastFooter/ToastFooter.module.scss
+++ b/src/components/UI/Toast/ToastFooter/ToastFooter.module.scss
@@ -1,0 +1,17 @@
+@import '../../../../index';
+
+$color: $--color-omega;
+$colorHover: $--color-omega-1;
+
+.toastFooter {
+  margin-bottom: 5px;
+}
+
+.transferLogLink {
+  cursor: pointer;
+  font-size: 11px;
+  line-height: 18px;
+  color: $color;
+  width: 114px;
+  text-decoration: underline;
+}

--- a/src/components/UI/Toast/ToastFooter/ToastFooter.strings.js
+++ b/src/components/UI/Toast/ToastFooter/ToastFooter.strings.js
@@ -1,0 +1,3 @@
+import {getString} from '../../../../utils';
+
+export const TRANSFER_LOG_LINK_BTN_TXT = getString('toasts.transfer_log_link');

--- a/src/components/UI/Toast/ToastHeader/ToastHeader.module.scss
+++ b/src/components/UI/Toast/ToastHeader/ToastHeader.module.scss
@@ -15,7 +15,7 @@ $color-title: $--color-black;
   }
 
   .close {
-    margin-left: 25px;
+    margin-left: 40px;
     cursor: pointer;
   }
 }

--- a/src/components/UI/Toast/TransferToast/TransferToast.js
+++ b/src/components/UI/Toast/TransferToast/TransferToast.js
@@ -3,11 +3,12 @@ import React from 'react';
 
 import {isConsumed, isPending, isRejected} from '../../../../enums';
 import {TransferData} from '../../../Features';
+import {ToastFooter, TransferLogLink} from '../ToastFooter/ToastFooter';
 import {ToastHeader} from '../ToastHeader/ToastHeader';
 import {ToastSeparator} from '../ToastSeparator/ToastSeparator';
 import {CONSUMED_TXT, PENDING_TXT, REJECTED_TXT} from './TransferToast.strings';
 
-export const TransferToast = ({transfer, isLoading, onClose}) => {
+export const TransferToast = ({transfer, isLoading, onTransferLogLink, onClose}) => {
   const getTitle = () => {
     const {status} = transfer;
     if (isPending(status)) {
@@ -26,6 +27,9 @@ export const TransferToast = ({transfer, isLoading, onClose}) => {
       <ToastHeader title={getTitle()} withClose={!isLoading} onClose={onClose} />
       <ToastSeparator />
       <TransferData style={{fontSize: '12px'}} transfer={transfer} />
+      <ToastFooter>
+        <TransferLogLink onClick={onTransferLogLink} />
+      </ToastFooter>
     </div>
   );
 };
@@ -33,5 +37,6 @@ export const TransferToast = ({transfer, isLoading, onClose}) => {
 TransferToast.propTypes = {
   transfer: PropTypes.object,
   isLoading: PropTypes.bool,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  onTransferLogLink: PropTypes.func
 };

--- a/src/components/UI/Toast/TransferToast/TransferToast.js
+++ b/src/components/UI/Toast/TransferToast/TransferToast.js
@@ -8,7 +8,7 @@ import {ToastHeader} from '../ToastHeader/ToastHeader';
 import {ToastSeparator} from '../ToastSeparator/ToastSeparator';
 import {CONSUMED_TXT, PENDING_TXT, REJECTED_TXT} from './TransferToast.strings';
 
-export const TransferToast = ({transfer, isLoading, onTransferLogLink, onClose}) => {
+export const TransferToast = ({transfer, isLoading, onTransferLogLinkClick, onClose}) => {
   const getTitle = () => {
     const {status} = transfer;
     if (isPending(status)) {
@@ -28,7 +28,7 @@ export const TransferToast = ({transfer, isLoading, onTransferLogLink, onClose})
       <ToastSeparator />
       <TransferData style={{fontSize: '12px'}} transfer={transfer} />
       <ToastFooter>
-        <TransferLogLink onClick={onTransferLogLink} />
+        <TransferLogLink onClick={onTransferLogLinkClick} />
       </ToastFooter>
     </div>
   );
@@ -38,5 +38,5 @@ TransferToast.propTypes = {
   transfer: PropTypes.object,
   isLoading: PropTypes.bool,
   onClose: PropTypes.func,
-  onTransferLogLink: PropTypes.func
+  onTransferLogLinkClick: PropTypes.func
 };

--- a/src/components/UI/TransferLogContainer/TransferLogContainer.js
+++ b/src/components/UI/TransferLogContainer/TransferLogContainer.js
@@ -12,7 +12,9 @@ import {
 } from './TransferLogContainer.strings';
 
 export const TransferLogContainer = ({transferIndex = null, children}) => {
-  const [showChildren, setShowChildren] = useState(transferIndex !== null);
+  const [showChildren, setShowChildren] = useState(
+    !!transferIndex || (0 === 0 && transferIndex > -1)
+  );
 
   const toggleShowChildren = () => {
     setShowChildren(!showChildren);

--- a/src/components/UI/TransferLogContainer/TransferLogContainer.js
+++ b/src/components/UI/TransferLogContainer/TransferLogContainer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {ReactComponent as CollapseIcon} from '../../../assets/svg/icons/collapse.svg';
 import {toClasses} from '../../../utils';
@@ -11,8 +11,12 @@ import {
   VIEW_MORE_TXT
 } from './TransferLogContainer.strings';
 
-export const TransferLogContainer = ({expanded, children}) => {
+export const TransferLogContainer = ({transferIndex, children}) => {
   const [showChildren, setShowChildren] = useState(false);
+
+  useEffect(() => {
+    setShowChildren((!!transferIndex || transferIndex === 0) && transferIndex > -1);
+  }, [transferIndex]);
 
   const toggleShowChildren = () => {
     setShowChildren(!showChildren);
@@ -21,7 +25,7 @@ export const TransferLogContainer = ({expanded, children}) => {
   const renderChildren = () => {
     if (!children) {
       return <div className={styles.empty}>{EMPTY_MSG_TXT}</div>;
-    } else if (!showChildren && !expanded) {
+    } else if (!showChildren) {
       return (
         <div className={styles.viewMore}>
           {Array.isArray(children) ? children.length : 1} {OVERVIEW_TXT}{' '}
@@ -50,5 +54,5 @@ export const TransferLogContainer = ({expanded, children}) => {
 
 TransferLogContainer.propTypes = {
   children: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
-  expanded: PropTypes.bool
+  transferIndex: PropTypes.number
 };

--- a/src/components/UI/TransferLogContainer/TransferLogContainer.js
+++ b/src/components/UI/TransferLogContainer/TransferLogContainer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {ReactComponent as CollapseIcon} from '../../../assets/svg/icons/collapse.svg';
 import {toClasses} from '../../../utils';
@@ -11,7 +11,7 @@ import {
   VIEW_MORE_TXT
 } from './TransferLogContainer.strings';
 
-export const TransferLogContainer = ({children}) => {
+export const TransferLogContainer = ({highlighted, children}) => {
   const [showChildren, setShowChildren] = useState(false);
 
   const toggleShowChildren = () => {
@@ -21,7 +21,7 @@ export const TransferLogContainer = ({children}) => {
   const renderChildren = () => {
     if (!children) {
       return <div className={styles.empty}>{EMPTY_MSG_TXT}</div>;
-    } else if (!showChildren) {
+    } else if (!showChildren && !highlighted) {
       return (
         <div className={styles.viewMore}>
           {Array.isArray(children) ? children.length : 1} {OVERVIEW_TXT}{' '}
@@ -32,6 +32,13 @@ export const TransferLogContainer = ({children}) => {
       return children;
     }
   };
+
+  useEffect(() => {
+    if (children && highlighted) {
+      const highlightedTransfer = children[highlighted];
+      console.log(highlightedTransfer);
+    }
+  }, [highlighted]);
 
   return (
     <div className={styles.transferLogContainer}>
@@ -49,5 +56,6 @@ export const TransferLogContainer = ({children}) => {
 };
 
 TransferLogContainer.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.array, PropTypes.object])
+  children: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  highlighted: PropTypes.number
 };

--- a/src/components/UI/TransferLogContainer/TransferLogContainer.js
+++ b/src/components/UI/TransferLogContainer/TransferLogContainer.js
@@ -3,6 +3,7 @@ import React, {useEffect, useState} from 'react';
 
 import {ReactComponent as CollapseIcon} from '../../../assets/svg/icons/collapse.svg';
 import {toClasses} from '../../../utils';
+import {useBridgeActions} from '../../Features/Bridge/Bridge.hooks';
 import styles from './TransferLogContainer.module.scss';
 import {
   EMPTY_MSG_TXT,
@@ -12,6 +13,7 @@ import {
 } from './TransferLogContainer.strings';
 
 export const TransferLogContainer = ({transferIndex, children}) => {
+  const {resetMenuProps} = useBridgeActions();
   const [showChildren, setShowChildren] = useState(transferIndex > 1);
 
   useEffect(() => {
@@ -19,6 +21,7 @@ export const TransferLogContainer = ({transferIndex, children}) => {
   }, [transferIndex]);
 
   const toggleShowChildren = () => {
+    resetMenuProps();
     setShowChildren(!showChildren);
   };
 

--- a/src/components/UI/TransferLogContainer/TransferLogContainer.js
+++ b/src/components/UI/TransferLogContainer/TransferLogContainer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 
 import {ReactComponent as CollapseIcon} from '../../../assets/svg/icons/collapse.svg';
 import {toClasses} from '../../../utils';
@@ -32,13 +32,6 @@ export const TransferLogContainer = ({highlighted, children}) => {
       return children;
     }
   };
-
-  useEffect(() => {
-    if (children && highlighted) {
-      const highlightedTransfer = children[highlighted];
-      console.log(highlightedTransfer);
-    }
-  }, [highlighted]);
 
   return (
     <div className={styles.transferLogContainer}>

--- a/src/components/UI/TransferLogContainer/TransferLogContainer.js
+++ b/src/components/UI/TransferLogContainer/TransferLogContainer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 
 import {ReactComponent as CollapseIcon} from '../../../assets/svg/icons/collapse.svg';
 import {toClasses} from '../../../utils';
@@ -14,30 +14,25 @@ import {
 
 export const TransferLogContainer = ({transferIndex, children}) => {
   const {resetMenuProps} = useBridgeActions();
-  const [showChildren, setShowChildren] = useState(transferIndex > 1);
-
-  useEffect(() => {
-    setShowChildren(transferIndex > -1);
-  }, [transferIndex]);
+  const [showChildren, setShowChildren] = useState(false);
 
   const toggleShowChildren = () => {
-    resetMenuProps();
-    setShowChildren(!showChildren);
+    transferIndex > -1 ? resetMenuProps() : setShowChildren(!showChildren);
   };
 
   const renderChildren = () => {
     if (!children) {
       return <div className={styles.empty}>{EMPTY_MSG_TXT}</div>;
-    } else if (!showChildren) {
-      return (
-        <div className={styles.viewMore}>
-          {Array.isArray(children) ? children.length : 1} {OVERVIEW_TXT}{' '}
-          <span onClick={toggleShowChildren}>{VIEW_MORE_TXT}</span>
-        </div>
-      );
-    } else {
+    } else if (showChildren || transferIndex > -1) {
       return children;
     }
+
+    return (
+      <div className={styles.viewMore}>
+        {Array.isArray(children) ? children.length : 1} {OVERVIEW_TXT}{' '}
+        <span onClick={toggleShowChildren}>{VIEW_MORE_TXT}</span>
+      </div>
+    );
   };
 
   return (

--- a/src/components/UI/TransferLogContainer/TransferLogContainer.js
+++ b/src/components/UI/TransferLogContainer/TransferLogContainer.js
@@ -12,10 +12,10 @@ import {
 } from './TransferLogContainer.strings';
 
 export const TransferLogContainer = ({transferIndex, children}) => {
-  const [showChildren, setShowChildren] = useState(false);
+  const [showChildren, setShowChildren] = useState(transferIndex > 1);
 
   useEffect(() => {
-    setShowChildren((!!transferIndex || transferIndex === 0) && transferIndex > -1);
+    setShowChildren(transferIndex > -1);
   }, [transferIndex]);
 
   const toggleShowChildren = () => {

--- a/src/components/UI/TransferLogContainer/TransferLogContainer.js
+++ b/src/components/UI/TransferLogContainer/TransferLogContainer.js
@@ -11,10 +11,8 @@ import {
   VIEW_MORE_TXT
 } from './TransferLogContainer.strings';
 
-export const TransferLogContainer = ({transferIndex = null, children}) => {
-  const [showChildren, setShowChildren] = useState(
-    !!transferIndex || (0 === 0 && transferIndex > -1)
-  );
+export const TransferLogContainer = ({expanded, children}) => {
+  const [showChildren, setShowChildren] = useState(false);
 
   const toggleShowChildren = () => {
     setShowChildren(!showChildren);
@@ -23,7 +21,7 @@ export const TransferLogContainer = ({transferIndex = null, children}) => {
   const renderChildren = () => {
     if (!children) {
       return <div className={styles.empty}>{EMPTY_MSG_TXT}</div>;
-    } else if (!showChildren) {
+    } else if (!showChildren && !expanded) {
       return (
         <div className={styles.viewMore}>
           {Array.isArray(children) ? children.length : 1} {OVERVIEW_TXT}{' '}
@@ -52,5 +50,5 @@ export const TransferLogContainer = ({transferIndex = null, children}) => {
 
 TransferLogContainer.propTypes = {
   children: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
-  transferIndex: PropTypes.number
+  expanded: PropTypes.bool
 };

--- a/src/components/UI/TransferLogContainer/TransferLogContainer.js
+++ b/src/components/UI/TransferLogContainer/TransferLogContainer.js
@@ -11,8 +11,8 @@ import {
   VIEW_MORE_TXT
 } from './TransferLogContainer.strings';
 
-export const TransferLogContainer = ({highlighted, children}) => {
-  const [showChildren, setShowChildren] = useState(false);
+export const TransferLogContainer = ({transferIndex = null, children}) => {
+  const [showChildren, setShowChildren] = useState(transferIndex !== null);
 
   const toggleShowChildren = () => {
     setShowChildren(!showChildren);
@@ -21,7 +21,7 @@ export const TransferLogContainer = ({highlighted, children}) => {
   const renderChildren = () => {
     if (!children) {
       return <div className={styles.empty}>{EMPTY_MSG_TXT}</div>;
-    } else if (!showChildren && !highlighted) {
+    } else if (!showChildren) {
       return (
         <div className={styles.viewMore}>
           {Array.isArray(children) ? children.length : 1} {OVERVIEW_TXT}{' '}
@@ -50,5 +50,5 @@ export const TransferLogContainer = ({highlighted, children}) => {
 
 TransferLogContainer.propTypes = {
   children: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
-  highlighted: PropTypes.number
+  transferIndex: PropTypes.number
 };

--- a/src/config/strings.json
+++ b/src/config/strings.json
@@ -85,6 +85,7 @@
   },
   "toasts": {
     "alpha_disclaimer_msg": "This is an ALPHA version of StarkNet, and its Bridge. As such, deyals may occur, and catastrophic bugs may lurk. Thanks, OGs, for trying it at this early stage.",
+    "transfer_log_link": "View On Transfer Log",
     "pendingTransfer": {
       "pending_txt": "Waiting for transaction to be accepted on L2",
       "consumed_txt": "Transaction accepted on L2",

--- a/src/config/strings.json
+++ b/src/config/strings.json
@@ -85,7 +85,7 @@
   },
   "toasts": {
     "alpha_disclaimer_msg": "This is an ALPHA version of StarkNet, and its Bridge. As such, deyals may occur, and catastrophic bugs may lurk. Thanks, OGs, for trying it at this early stage.",
-    "transfer_log_link": "View On Transfer Log",
+    "transfer_log_link": "View on Transfer Log",
     "pendingTransfer": {
       "pending_txt": "Waiting for transaction to be accepted on L2",
       "consumed_txt": "Transaction accepted on L2",

--- a/src/styles/colors.module.scss
+++ b/src/styles/colors.module.scss
@@ -12,6 +12,7 @@ $--color-alpha-5-hover: #494a81;
 $--color-alpha-6: #8b8dc2;
 $--color-alpha-6-hover: #999bc5;
 $--color-beta: #f6643c;
+$--color-beta-1: rgba(246, 100, 60, 0.56);
 $--color-gamma: #69b7f9;
 $--color-gamma-1: #1595ff;
 $--color-omega: #5f666c;

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -24,6 +24,9 @@ export const evaluate = (template, model) => {
 };
 
 export const findIndexById = (array, id) => {
-  if (!array || !array.length || (!id && id !== '0' && id !== 0)) return -1;
-  else return array.findIndex(item => item.id === id);
+  if (!array || !array.length || (!id && id !== '0' && id !== 0)) {
+    return -1;
+  } else {
+    return array.findIndex(item => item.id === id);
+  }
 };

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -24,9 +24,5 @@ export const evaluate = (template, model) => {
 };
 
 export const findIndexById = (array, id) => {
-  if (!Array.isArray(array)) {
-    return -1;
-  } else {
-    return array.findIndex(item => item.id === id);
-  }
+  return array.findIndex(item => item.id === id);
 };

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -22,3 +22,8 @@ export const evaluate = (template, model) => {
     return '';
   }
 };
+
+export const findIndexById = (array, id) => {
+  if (!array || (!id && id !== 0)) return;
+  else return array.findIndex(item => item.id === id);
+};

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -24,6 +24,6 @@ export const evaluate = (template, model) => {
 };
 
 export const findIndexById = (array, id) => {
-  if (!array || (!id && id !== 0)) return;
+  if (!array || !array.length || (!id && id !== '0' && id !== 0)) return -1;
   else return array.findIndex(item => item.id === id);
 };

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -24,7 +24,7 @@ export const evaluate = (template, model) => {
 };
 
 export const findIndexById = (array, id) => {
-  if (!array || !array.length || (!id && id !== '0' && id !== 0)) {
+  if (!Array.isArray(array)) {
     return -1;
   } else {
     return array.findIndex(item => item.id === id);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2545,14 +2545,6 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/jest@^26.0.24":
-  version "26.0.24"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
-  integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==
-  dependencies:
-    jest-diff "^26.0.0"
-    pretty-format "^26.0.0"
-
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -10064,7 +10056,7 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^26.0.0, jest-diff@^26.6.2:
+jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -13540,7 +13532,7 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^26.0.0, pretty-format@^26.6.0, pretty-format@^26.6.2:
+pretty-format@^26.6.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==


### PR DESCRIPTION
enhancement:
Added to the toasts link to transfer-log. onClick switches to L1 or L2, and opens the account menu with the log expanded. Added 'menuProps' to Bridge.js, currently used only by the account menu.

- [x] Changes have been done against master branch, and PR does not conflict
- [x] New unit / functional tests have been added (whenever applicable)
- [x] Test are passing in local environment
- [ ] Docs have been updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/76)
<!-- Reviewable:end -->
