### PR TITLE
fix: redux error on switching menu "non-serializable value was detected"

### DIFF
--- a/src/components/Features/Account/Account.js
+++ b/src/components/Features/Account/Account.js
@@ -43,7 +43,7 @@ export const Account = ({transferId}) => {
   return (
     <Menu>
       <div className={styles.account}>
-        <BackButton onClick={showTransferMenu} />
+        <BackButton onClick={() => showTransferMenu()} />
         <MenuTitle text={TITLE_TXT(fromNetwork.name)} />
         <AccountAddress address={account} />
         {isL1 && (

--- a/src/components/Features/SelectToken/SelectToken.js
+++ b/src/components/Features/SelectToken/SelectToken.js
@@ -31,7 +31,7 @@ export const SelectToken = () => {
   return (
     <Menu>
       <div className={styles.selectToken}>
-        <BackButton onClick={showTransferMenu} />
+        <BackButton onClick={() => showTransferMenu()} />
         <MenuTitle text={TITLE_TXT} />
         <MenuTitle color={colorBeta} text={fromNetwork.name} />
         <SearchToken


### PR DESCRIPTION
Calling the function 'showTransferMenu' from clicking on the 'Account.js' + 'SelectToken.js' > backButton was accidentally passing the click-event.
This PR fixes that. Now it's clear that all calls to the function 'showTransferMenu' don't pass the browser event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/89)
<!-- Reviewable:end -->
