### PR TITLE
fix: remove pending transfer toast

### DIFF
--- a/src/components/Features/ToastProvider/ToastProvider.js
+++ b/src/components/Features/ToastProvider/ToastProvider.js
@@ -3,14 +3,7 @@ import React, {useEffect, useRef} from 'react';
 import {toast, Toaster} from 'react-hot-toast';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 
-import {
-  ActionType,
-  isConsumed,
-  isOnChain,
-  isPending,
-  isRejected,
-  NetworkType
-} from '../../../enums';
+import {ActionType, isConsumed, isOnChain, isRejected, NetworkType} from '../../../enums';
 import {useCompleteTransferToL1, usePrevious} from '../../../hooks';
 import {useTransfers} from '../../../providers/TransfersProvider';
 import utils from '../../../utils';

--- a/src/components/Features/ToastProvider/ToastProvider.js
+++ b/src/components/Features/ToastProvider/ToastProvider.js
@@ -44,9 +44,6 @@ export const ToastProvider = () => {
   const handleToast = (transfer, prevTransfer) => {
     const {status, type} = transfer;
     const isChanged = prevTransfer && status !== prevTransfer.status;
-    if (isPending(status)) {
-      return showPendingTransferToast(transfer);
-    }
     if (isChanged && isConsumed(status)) {
       return showConsumedTransferToast(transfer);
     }
@@ -58,6 +55,7 @@ export const ToastProvider = () => {
     }
   };
 
+  /* eslint-disable-next-line */
   const showPendingTransferToast = transfer => {
     let toastId = getToastId(transfer);
     if (!toastId) {


### PR DESCRIPTION
Remove the call to show the toast: "Waiting for transaction to be accepted on L2..."
Keep all related code written, because soon we might want to re-display it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/92)
<!-- Reviewable:end -->
