### PR TITLE
feat: add discord tab

### DIFF
--- a/src/components/Containers/Header/Header.js
+++ b/src/components/Containers/Header/Header.js
@@ -38,7 +38,7 @@ export const Header = () => {
   };
 
   const onTabDiscordClick = () => {
-    utils.browser.openInNewTab(DISCORD_LINK_URL.url, DISCORD_LINK_URL.target);
+    utils.browser.openInNewTab(DISCORD_LINK_URL, DISCORD_LINK_URL);
   };
 
   return (

--- a/src/components/Containers/Header/Header.js
+++ b/src/components/Containers/Header/Header.js
@@ -2,14 +2,15 @@ import React from 'react';
 import useBreakpoint from 'use-breakpoint';
 
 import {ReactComponent as StarkGateLogo} from '../../../assets/img/starkgate.svg';
+import constants from '../../../config/constants';
 import {Breakpoint} from '../../../enums';
 import {useMenu} from '../../../providers/MenuProvider';
 import {useIsL1, useIsL2} from '../../../providers/TransferProvider';
 import {useL1Wallet, useL2Wallet, useWallets} from '../../../providers/WalletsProvider';
 import utils from '../../../utils';
-import {WalletButton} from '../../UI';
+import {WalletButton, Tab} from '../../UI';
 import styles from './Header.module.scss';
-import {CHAIN_TXT} from './Header.strings';
+import {CHAIN_TXT, TAB_DISCORD} from './Header.strings';
 
 export const Header = () => {
   const {chainName, isConnected} = useWallets();
@@ -19,6 +20,7 @@ export const Header = () => {
   const {account: l1Account, isConnected: isL1AccountConnected, config: l1Config} = useL1Wallet();
   const {account: l2Account, isConnected: isL2AccountConnected, config: l2Config} = useL2Wallet();
   const {breakpoint} = useBreakpoint(Breakpoint);
+  const {DISCORD} = constants;
 
   const onL2WalletButtonClick = () => {
     swapToL2();
@@ -34,6 +36,10 @@ export const Header = () => {
     showTransferMenu();
   };
 
+  const onTabDiscordClick = () => {
+    utils.browser.openInNewTab(DISCORD.url, DISCORD.target);
+  };
+
   return (
     <div className={utils.object.toClasses(styles.header, styles[breakpoint.toLowerCase()], 'row')}>
       <div className={utils.object.toClasses(styles.left, 'row')}>
@@ -46,6 +52,7 @@ export const Header = () => {
       </div>
 
       <div className={utils.object.toClasses(styles.right, 'row')}>
+        <Tab label={TAB_DISCORD} onClick={onTabDiscordClick}></Tab>
         {isL1AccountConnected && (
           <WalletButton
             account={l1Account}

--- a/src/components/Containers/Header/Header.js
+++ b/src/components/Containers/Header/Header.js
@@ -12,6 +12,8 @@ import {WalletButton, Tab} from '../../UI';
 import styles from './Header.module.scss';
 import {CHAIN_TXT, TAB_DISCORD} from './Header.strings';
 
+const {DISCORD_LINK_URL} = constants;
+
 export const Header = () => {
   const {chainName, isConnected} = useWallets();
   const {showAccountMenu, showTransferMenu} = useMenu();
@@ -20,7 +22,6 @@ export const Header = () => {
   const {account: l1Account, isConnected: isL1AccountConnected, config: l1Config} = useL1Wallet();
   const {account: l2Account, isConnected: isL2AccountConnected, config: l2Config} = useL2Wallet();
   const {breakpoint} = useBreakpoint(Breakpoint);
-  const {DISCORD} = constants;
 
   const onL2WalletButtonClick = () => {
     swapToL2();
@@ -37,7 +38,7 @@ export const Header = () => {
   };
 
   const onTabDiscordClick = () => {
-    utils.browser.openInNewTab(DISCORD.url, DISCORD.target);
+    utils.browser.openInNewTab(DISCORD_LINK_URL.url, DISCORD_LINK_URL.target);
   };
 
   return (

--- a/src/components/Containers/Header/Header.js
+++ b/src/components/Containers/Header/Header.js
@@ -10,7 +10,7 @@ import {useL1Wallet, useL2Wallet, useWallets} from '../../../providers/WalletsPr
 import utils from '../../../utils';
 import {WalletButton, Tab} from '../../UI';
 import styles from './Header.module.scss';
-import {CHAIN_TXT, TAB_DISCORD} from './Header.strings';
+import {CHAIN_TXT, TAB_DISCORD_TXT} from './Header.strings';
 
 const {DISCORD_LINK_URL} = constants;
 
@@ -53,7 +53,7 @@ export const Header = () => {
       </div>
 
       <div className={utils.object.toClasses(styles.right, 'row')}>
-        <Tab label={TAB_DISCORD} onClick={onTabDiscordClick}></Tab>
+        <Tab label={TAB_DISCORD_TXT} onClick={onTabDiscordClick}></Tab>
         {isL1AccountConnected && (
           <WalletButton
             account={l1Account}

--- a/src/components/Containers/Header/Header.module.scss
+++ b/src/components/Containers/Header/Header.module.scss
@@ -53,6 +53,8 @@ $chain-color: $--color-white-1;
   }
 
   .right {
+    margin-left: 20px;
+
     button {
       &:not(:last-child) {
         margin-right: 10px;

--- a/src/components/Containers/Header/Header.strings.js
+++ b/src/components/Containers/Header/Header.strings.js
@@ -4,3 +4,5 @@ export const CHAIN_TXT = chainName =>
   utils.string.capitalize(
     utils.object.evaluate(utils.getTranslation('containers.header.chain_txt'), {chainName})
   );
+
+export const TAB_DISCORD = utils.getTranslation('containers.header.tab_discord');

--- a/src/components/Containers/Header/Header.strings.js
+++ b/src/components/Containers/Header/Header.strings.js
@@ -5,4 +5,4 @@ export const CHAIN_TXT = chainName =>
     utils.object.evaluate(utils.getTranslation('containers.header.chain_txt'), {chainName})
   );
 
-export const TAB_DISCORD = utils.getTranslation('containers.header.tab_discord');
+export const TAB_DISCORD = utils.getTranslation('containers.header.tab_discord_txt');

--- a/src/components/Containers/Header/Header.strings.js
+++ b/src/components/Containers/Header/Header.strings.js
@@ -5,4 +5,4 @@ export const CHAIN_TXT = chainName =>
     utils.object.evaluate(utils.getTranslation('containers.header.chain_txt'), {chainName})
   );
 
-export const TAB_DISCORD = utils.getTranslation('containers.header.tab_discord_txt');
+export const TAB_DISCORD_TXT = utils.getTranslation('containers.header.tab_discord_txt');

--- a/src/components/UI/Tab/Tab.js
+++ b/src/components/UI/Tab/Tab.js
@@ -3,13 +3,14 @@ import React from 'react';
 
 import styles from './Tab.module.scss';
 
-export const Tab = ({onClick, label}) => {
+export const Tab = ({label, onClick}) => {
   return (
     <button className={styles.tab} onClick={() => onClick()}>
       {label}
     </button>
   );
 };
+
 Tab.propTypes = {
   label: PropTypes.string,
   onClick: PropTypes.func

--- a/src/components/UI/Tab/Tab.js
+++ b/src/components/UI/Tab/Tab.js
@@ -5,7 +5,7 @@ import styles from './Tab.module.scss';
 
 export const Tab = ({label, onClick}) => {
   return (
-    <button className={styles.tab} onClick={() => onClick()}>
+    <button className={styles.tab} onClick={onClick}>
       {label}
     </button>
   );

--- a/src/components/UI/Tab/Tab.js
+++ b/src/components/UI/Tab/Tab.js
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import styles from './Tab.module.scss';
+
+export const Tab = ({onClick, label}) => {
+  return (
+    <button className={styles.tab} onClick={() => onClick()}>
+      {label}
+    </button>
+  );
+};
+Tab.propTypes = {
+  label: PropTypes.string,
+  onClick: PropTypes.func
+};

--- a/src/components/UI/Tab/Tab.module.scss
+++ b/src/components/UI/Tab/Tab.module.scss
@@ -1,0 +1,30 @@
+@import '../../../index';
+
+$color: $--color-white;
+$active-color: $--color-beta;
+
+.tab {
+  text-align: center;
+  text-transform: capitalize;
+  font-weight: bold;
+  font-size: 14px;
+  line-height: 1.2;
+  margin: 10px 0;
+  padding: 20px 0;
+  cursor: pointer;
+  background-color: transparent;
+  color: $color;
+  text-decoration: none;
+  box-sizing: border-box;
+  border: 2px solid transparent;
+  border-radius: 7px;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:active {
+    color: $active-color;
+    text-decoration-color: $active-color;
+  }
+}

--- a/src/components/UI/WalletButton/WalletButton.module.scss
+++ b/src/components/UI/WalletButton/WalletButton.module.scss
@@ -5,6 +5,10 @@
 
   &.mobile {
     width: 80px;
+
+    img {
+      margin-right: 0;
+    }
   }
 
   &.tablet {

--- a/src/components/UI/index.js
+++ b/src/components/UI/index.js
@@ -15,6 +15,7 @@ export * from './MaxButton/MaxButton';
 export * from './NetworkMenu/NetworkMenu';
 export * from './NetworkSwap/NetworkSwap';
 export * from './NetworkTitle/NetworkTitle';
+export * from './Tab/Tab';
 export * from './TokenBalance/TokenBalance';
 export * from './TokenInput/TokenInput';
 export * from './TokenSelector/TokenSelector';

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -33,10 +33,7 @@ const constants = {
         })
     }
   },
-  DISCORD_LINK_URL: {
-    url: 'https://discord.gg/MRjKBXtaDt',
-    target: 'Discord StarkGate Channel'
-  }
+  DISCORD_LINK_URL: '//discord.gg/MRjKBXtaDt'
 };
 
 export default constants;

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -33,7 +33,7 @@ const constants = {
         })
     }
   },
-  DISCORD: {
+  DISCORD_LINK_URL: {
     url: 'https://discord.gg/MRjKBXtaDt',
     target: 'Discord StarkGate Channel'
   }

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -32,6 +32,10 @@ const constants = {
           account
         })
     }
+  },
+  DISCORD: {
+    url: 'https://discord.gg/MRjKBXtaDt',
+    target: 'Discord StarkGate Channel'
   }
 };
 

--- a/src/config/strings.js
+++ b/src/config/strings.js
@@ -3,7 +3,7 @@ const strings = {
     header: {
       chain_txt: '{{chainName}} testnet',
       wallet_btn_txt: 'Account | {{address}}',
-      tab_discord: 'Discord'
+      tab_discord_txt: 'StarkGate Discord Channel'
     },
     footer: {
       rights_txt: '© 2022 StarkWare Industries Ltd. All Rights Reserved'

--- a/src/config/strings.js
+++ b/src/config/strings.js
@@ -2,7 +2,8 @@ const strings = {
   containers: {
     header: {
       chain_txt: '{{chainName}} testnet',
-      wallet_btn_txt: 'Account | {{address}}'
+      wallet_btn_txt: 'Account | {{address}}',
+      tab_discord: 'Discord'
     },
     footer: {
       rights_txt: '© 2022 StarkWare Industries Ltd. All Rights Reserved'

--- a/src/config/strings.js
+++ b/src/config/strings.js
@@ -3,7 +3,7 @@ const strings = {
     header: {
       chain_txt: '{{chainName}} testnet',
       wallet_btn_txt: 'Account | {{address}}',
-      tab_discord_txt: 'StarkGate Discord Channel'
+      tab_discord_txt: 'Discord'
     },
     footer: {
       rights_txt: '© 2022 StarkWare Industries Ltd. All Rights Reserved'

--- a/src/utils/browser.js
+++ b/src/utils/browser.js
@@ -1,5 +1,5 @@
-export const openInNewTab = url => {
-  window.open(url, '_blank').focus();
+export const openInNewTab = (url, target) => {
+  window.open(url, target || '_blank');
 };
 
 export const getUrlParameter = name => {


### PR DESCRIPTION
Add a new Tab component, use it in Header with link to StarkNet channel on discord.
Edit _utils.browser.openInNewTab_ to accept argument 'target' -
   Specify it for the discord link, so it focuses on that tab if already opened before.

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [standard-version](https://www.conventionalcommits.org/) convention: `<type>(optional subject): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/104)
<!-- Reviewable:end -->
