### PR TITLE
fix: terms change bottom text

### DIFF
--- a/src/components/UI/FullScreenContainer/FullScreenContainer.module.scss
+++ b/src/components/UI/FullScreenContainer/FullScreenContainer.module.scss
@@ -29,6 +29,7 @@ $shadow-color: $--color-black;
 
   &.mobile {
     padding: 0 20px;
+    bottom: 0;
   }
 
   a {

--- a/src/components/UI/FullScreenContainer/FullScreenContainer.module.scss
+++ b/src/components/UI/FullScreenContainer/FullScreenContainer.module.scss
@@ -19,7 +19,7 @@ $shadow-color: $--color-black;
   text-shadow: 1px 1px $shadow-color;
   transition: 0.3s ease-in-out;
 
-  > * > *:last-child {
+  > *:first-child > *:last-child {
     margin-bottom: 70px;
   }
 

--- a/src/components/UI/FullScreenContainer/FullScreenContainer.module.scss
+++ b/src/components/UI/FullScreenContainer/FullScreenContainer.module.scss
@@ -19,6 +19,10 @@ $shadow-color: $--color-black;
   text-shadow: 1px 1px $shadow-color;
   transition: 0.3s ease-in-out;
 
+  > * > *:last-child {
+    margin-bottom: 70px;
+  }
+
   &.laptop {
     padding: 0 200px;
   }

--- a/src/routes/Terms/Terms.js
+++ b/src/routes/Terms/Terms.js
@@ -532,6 +532,7 @@ export const Terms = () => {
       </div>
       {!isAcceptTerms && (
         <div ref={acceptButtonRef} className={styles.acceptButton}>
+          <p>By clicking the &#34;I Accept&#34; button, you are accepting these Terms of Service</p>
           <Button
             colorBackground={colorGamma1}
             colorBackgroundHover={colorGamma1}
@@ -545,12 +546,6 @@ export const Terms = () => {
             text={ACCEPT_BTN_TXT}
             onClick={accept}
           />
-          <p>
-            By clicking the &#34;I Accept&#34; button, you are accepting our{' '}
-            <a href={`${appUrl}/terms`} rel="noreferrer" target="_blank">
-              Terms of Service
-            </a>
-          </p>
         </div>
       )}
     </FullScreenContainer>

--- a/src/routes/Terms/Terms.js
+++ b/src/routes/Terms/Terms.js
@@ -551,7 +551,6 @@ export const Terms = () => {
       </div>
       {!isAcceptTerms && (
         <div ref={acceptButtonRef} className={styles.acceptButton}>
-          <p>By clicking the &#34;I Accept&#34; button, you are accepting these Terms of Service</p>
           <Button
             colorBackground={colorGamma1}
             colorBackgroundHover={colorGamma1}
@@ -565,6 +564,7 @@ export const Terms = () => {
             text={ACCEPT_BTN_TXT}
             onClick={accept}
           />
+          <p>By clicking the &#34;I Accept&#34; button, you are accepting these Terms of Service</p>
         </div>
       )}
     </FullScreenContainer>

--- a/src/routes/Terms/Terms.module.scss
+++ b/src/routes/Terms/Terms.module.scss
@@ -21,6 +21,8 @@
   }
 
   .notes {
+    margin-bottom: 70px;
+
     h3 {
       margin-bottom: 0;
       line-height: 1;

--- a/src/routes/Terms/Terms.module.scss
+++ b/src/routes/Terms/Terms.module.scss
@@ -21,8 +21,6 @@
   }
 
   .notes {
-    margin-bottom: 70px;
-
     h3 {
       margin-bottom: 0;
       line-height: 1;


### PR DESCRIPTION
Change text from '**our** Terms of Service' to: '**these** Terms of Service', and remove the redundant (and broken) link from that text. add some margin-bottom to the content of 'fullScreenContainer' first-child.
In .fullScreenContainer.isMobile make 'bottom' 0 because the footer is set not to render.

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/148)
<!-- Reviewable:end -->
