### PR TITLE
fix: app crashed when trying to connect while ArgentX wasn't installed

### DIFF
--- a/src/config/envs.js
+++ b/src/config/envs.js
@@ -3,7 +3,7 @@ import utils from '../utils';
 const envs = {
   env: process.env.NODE_ENV,
   appUrl: process.env.REACT_APP_URL,
-  autoConnect: Boolean(process.env.REACT_APP_AUTO_CONNECT),
+  autoConnect: process.env.REACT_APP_AUTO_CONNECT === 'true',
   pollBlockNumberInterval: Number(process.env.REACT_APP_POLL_BLOCK_NUMBER_INTERVAL),
   supportedTokens: process.env.REACT_APP_SUPPORTED_TOKENS.split(','),
   supportedChainId: Number(process.env.REACT_APP_SUPPORTED_CHAIN_ID),

--- a/src/providers/WalletsProvider/WalletsProvider.js
+++ b/src/providers/WalletsProvider/WalletsProvider.js
@@ -41,8 +41,11 @@ export const WalletsProvider = ({children}) => {
   };
 
   const connectL2Wallet = async walletConfig => {
-    await getStarknet().enable(!autoConnect && {showModal: true});
-    setL2WalletConfig(walletConfig);
+    try {
+      await getStarknet().enable(!autoConnect && {showModal: true});
+      setL2WalletConfig(walletConfig);
+      // eslint-disable-next-line no-empty
+    } catch {}
   };
 
   const resetWallet = () => {


### PR DESCRIPTION
fix the condition envs.js > autoConnect represents, to reflect properly the settings in the env;
Add try-catch in connectL2Wallet, since in the scenario of ArgentX not installed- the enable function throws.
With these fixes, when in the current environment defined auto-connect = false, if ArgentX isn't installed in the browser-
The 'prompt install' modal is displayed, and the error of 'no starknet found in window' is caught.

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/153)
<!-- Reviewable:end -->
