### PR TITLE
fix: accept button stays disabled when zoom is different from 100%

### DIFF
--- a/src/routes/Terms/Terms.js
+++ b/src/routes/Terms/Terms.js
@@ -35,7 +35,7 @@ export const Terms = () => {
   const onScroll = () => {
     if (termsRef.current) {
       const {scrollTop, scrollHeight, clientHeight} = termsRef.current;
-      if (scrollTop + clientHeight === scrollHeight) {
+      if (Math.ceil(scrollTop + clientHeight) >= scrollHeight) {
         setAcceptButtonEnable(true);
       }
     }


### PR DESCRIPTION
### Description of the Changes

Solution: check for `scrollTop + clientHeight >= scrollHeight` and round-up the result instead of `scrollTop + clientHeight === scrollHeight`

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/155)
<!-- Reviewable:end -->
