### PR TITLE
fix: bad overflow in modal for content with very long strings

### DIFF
--- a/src/components/UI/Modal/Modal/Modal.js
+++ b/src/components/UI/Modal/Modal/Modal.js
@@ -12,7 +12,10 @@ export const Modal = ({show, type = ModalType.INFO, size = ModalSize.MEDIUM, chi
   return show
     ? createPortal(
         <div className={utils.object.toClasses(styles.modal, styles[type])}>
-          <div className={utils.object.toClasses(styles.container, styles[type])} style={{width}}>
+          <div
+            className={utils.object.toClasses(styles.container, styles[type])}
+            style={{width, maxWidth: width}}
+          >
             {children}
           </div>
         </div>,

--- a/src/components/UI/Modal/ModalBody/ModalBody.module.scss
+++ b/src/components/UI/Modal/ModalBody/ModalBody.module.scss
@@ -9,6 +9,8 @@
   white-space: break-spaces;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: inherit;
+  overflow-wrap: break-word;
 
   &.error {
     color: $--color-error;

--- a/src/components/UI/Modal/ModalText/ModalText.module.scss
+++ b/src/components/UI/Modal/ModalText/ModalText.module.scss
@@ -2,16 +2,19 @@
   font-weight: 400;
   font-size: 17px;
   letter-spacing: 0.03em;
+  max-width: inherit;
 
   .wrap {
     float: left;
     position: relative;
     left: 50%;
+    max-width: inherit;
 
     .content {
       float: left;
       position: relative;
       left: -50%;
+      max-width: inherit;
     }
   }
 }


### PR DESCRIPTION
Set also a max-width and an 'overflow-wrap' so modal-content that has very long strings (like in some error messages) will wrap correctly. Yet, keep the centered style for short content.

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/161)
<!-- Reviewable:end -->
