### PR TITLE
fix: rejected transactions were logged in the transfer-log

### DIFF
--- a/src/hooks/useTransferToL1.js
+++ b/src/hooks/useTransferToL1.js
@@ -173,9 +173,9 @@ export const useCompleteTransferToL1 = () => {
             stepOf(TransferStep.CONFIRM_TX, CompleteTransferToL1Steps)
           )
         );
-        addWithdrawalListener(onWithdrawal);
         logger.log('Calling withdraw');
         await sendWithdrawal();
+        addWithdrawalListener(onWithdrawal);
       } catch (ex) {
         trackError(ex);
         logger.error(ex.message, {ex});

--- a/src/hooks/useTransferToL2.js
+++ b/src/hooks/useTransferToL2.js
@@ -170,9 +170,9 @@ export const useTransferToL2 = () => {
             stepOf(TransferStep.CONFIRM_TX, TransferToL2Steps)
           )
         );
-        addDepositListener(onDeposit);
         logger.log('Calling deposit');
         await sendDeposit();
+        addDepositListener(onDeposit);
       } catch (ex) {
         trackError(ex);
         logger.error(ex.message, {ex});


### PR DESCRIPTION
add the listener to a tx only after its start (and wasn't rejected). That way rejected transactions won't appear in the TransferLog.


### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/164)
<!-- Reviewable:end -->
