### PR TITLE
fix: calc L2 tx hash in the background

### DIFF
--- a/src/components/UI/Modal/TransactionSubmittedModal/TransactionSubmittedModal.js
+++ b/src/components/UI/Modal/TransactionSubmittedModal/TransactionSubmittedModal.js
@@ -48,10 +48,7 @@ const TransactionSubmittedModal = ({transfer}) => {
     });
   }
 
-  if (
-    (type === ActionType.TRANSFER_TO_L1 && !isTransferCompleted) ||
-    type === ActionType.TRANSFER_TO_L2
-  ) {
+  if (type === ActionType.TRANSFER_TO_L1 && !isTransferCompleted) {
     explorerButtons.push({
       explorerName: VOYAGER,
       explorerUrl: voyagerTxUrl(l2hash),

--- a/src/hooks/useTransferToL1.js
+++ b/src/hooks/useTransferToL1.js
@@ -136,9 +136,7 @@ export const useCompleteTransferToL1 = () => {
       };
 
       const onTransactionHash = (error, transactionHash) => {
-        if (error) {
-          onError(error);
-        } else {
+        if (!error) {
           logger.log('Tx signed', {transactionHash});
           handleProgress(
             progressOptions.withdraw(
@@ -151,11 +149,9 @@ export const useCompleteTransferToL1 = () => {
       };
 
       const onWithdrawal = (error, event) => {
-        if (error) {
-          onError(error);
-        } else {
+        if (!error) {
+          logger.log('Withdrawal event dispatched', event);
           const {transactionHash: l1hash} = event;
-          logger.log('Done', l1hash);
           trackSuccess(l1hash);
           handleData({...transfer, l1hash});
         }

--- a/src/hooks/useTransferToL1.js
+++ b/src/hooks/useTransferToL1.js
@@ -157,13 +157,6 @@ export const useCompleteTransferToL1 = () => {
         }
       };
 
-      const onError = error => {
-        removeListener();
-        trackError(error);
-        logger.error(error?.message, error);
-        handleError(progressOptions.error(TransferError.TRANSACTION_ERROR, error));
-      };
-
       try {
         logger.log('CompleteTransferToL1 called');
         handleProgress(
@@ -176,7 +169,10 @@ export const useCompleteTransferToL1 = () => {
         logger.log('Calling withdraw');
         await sendWithdrawal();
       } catch (ex) {
-        onError(ex);
+        removeListener();
+        trackError(ex);
+        logger.error(ex?.message, ex);
+        handleError(progressOptions.error(TransferError.TRANSACTION_ERROR, ex));
       }
     },
     [

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import {App} from './App';
 import {ModalWrapper} from './components/UI';
 import envs from './config/envs';
 import './index.scss';
-import {Providers} from './providers';
+import {AppProviders} from './providers';
 import utils from './utils';
 
 const {env} = envs;
@@ -24,10 +24,10 @@ if (env === 'development' || utils.browser.getUrlParameter('debugApp')) {
 
 ReactDOM.render(
   <BrowserRouter>
-    <Providers>
+    <AppProviders>
       <App />
       <ModalWrapper />
-    </Providers>
+    </AppProviders>
   </BrowserRouter>,
   document.getElementById('root')
 );

--- a/src/providers/EventManagerProvider/event-manager-hooks.js
+++ b/src/providers/EventManagerProvider/event-manager-hooks.js
@@ -29,11 +29,15 @@ export const useDepositMessageToL2Event = () => {
   const {getPastEvents} = useContext(EventManagerContext);
   const starknetContract = useStarknetContract();
 
-  return useCallback(async depositEvent => {
-    const {blockNumber, transactionHash} = depositEvent;
-    const pastEvents = await getPastEvents(starknetContract, EventName.L1.LOG_MESSAGE_TO_L2, {
-      fromBlock: blockNumber
-    });
-    return pastEvents.find(e => e.transactionHash === transactionHash);
-  }, []);
+  return useCallback(
+    async depositEvent => {
+      const {blockNumber, transactionHash} = depositEvent;
+      const pastEvents = await getPastEvents(starknetContract, EventName.L1.LOG_MESSAGE_TO_L2, {
+        fromBlock: blockNumber - 1,
+        toBlock: 'latest'
+      });
+      return pastEvents.find(e => e.transactionHash === transactionHash);
+    },
+    [starknetContract]
+  );
 };

--- a/src/providers/WalletsProvider/WalletsProvider.js
+++ b/src/providers/WalletsProvider/WalletsProvider.js
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types';
 import React, {useEffect, useReducer} from 'react';
 import {useWallet} from 'use-wallet';
 
+import {WalletStatus} from '../../enums';
 import {useIsL1, useIsL2} from '../TransferProvider';
 import {WalletsContext} from './wallets-context';
 import {useStarknetWallet} from './wallets-hooks';
 import {actions, initialState, reducer} from './wallets-reducer';
-import {WalletStatus} from '../../enums';
 
 export const WalletsProvider = ({children}) => {
   const [state, dispatch] = useReducer(reducer, initialState);

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -1,20 +1,27 @@
 import {AppProvider} from './AppProvider';
 import {BlockHashProvider} from './BlockHashProvider';
+import {EventManagerProvider} from './EventManagerProvider';
 import {MenuProvider} from './MenuProvider';
 import {ModalProvider} from './ModalProvider';
+import {TokensProvider} from './TokensProvider';
 import {TransferProvider} from './TransferProvider';
 import {TransfersLogProvider} from './TransfersLogProvider';
 import {WalletProvider} from './WalletProvider/WalletProvider';
 import {WalletsProvider} from './WalletsProvider';
 import {combineProviders} from './combine-providers';
 
-export const Providers = combineProviders([
+export const AppProviders = combineProviders([
   AppProvider,
   MenuProvider,
   TransferProvider,
   ModalProvider,
   WalletProvider,
   WalletsProvider,
-  BlockHashProvider,
+  BlockHashProvider
+]);
+
+export const BridgeProviders = combineProviders([
+  TokensProvider,
+  EventManagerProvider,
   TransfersLogProvider
 ]);

--- a/src/routes/Bridge/Bridge.js
+++ b/src/routes/Bridge/Bridge.js
@@ -4,10 +4,9 @@ import {setUser} from '../../analytics';
 import {Account, SelectToken, ToastProvider, Transfer} from '../../components/Features';
 import {MenuType} from '../../enums';
 import {useEnvs, useMenuTracking} from '../../hooks';
-import {EventManagerProvider} from '../../providers/EventManagerProvider';
+import {BridgeProviders} from '../../providers';
 import {useMenu} from '../../providers/MenuProvider';
 import {useOnboardingModal} from '../../providers/ModalProvider';
-import {TokensProvider} from '../../providers/TokensProvider';
 import {useL1Wallet, useL2Wallet} from '../../providers/WalletsProvider';
 import utils from '../../utils';
 import styles from './Bridge.module.scss';
@@ -56,14 +55,12 @@ export const Bridge = () => {
 
   return (
     <div className={styles.bridge}>
-      <TokensProvider>
-        <EventManagerProvider>
-          <div className={styles.bridgeMenu}>
-            <ToastProvider />
-            {renderMenu()}
-          </div>
-        </EventManagerProvider>
-      </TokensProvider>
+      <BridgeProviders>
+        <div className={styles.bridgeMenu}>
+          <ToastProvider />
+          {renderMenu()}
+        </div>
+      </BridgeProviders>
     </div>
   );
 };


### PR DESCRIPTION
### Description of the Changes

Do not enforce the modal to stay on screen if you have not been able to calculate the L2 hash (the transaction itself has already been sent). Keep doing it in the background when iterating the transfers.

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/169)
<!-- Reviewable:end -->
