### PR TITLE
fix: use wallet provider for all provider calls

### DIFF
--- a/src/providers/BlockHashProvider/BlockHashProvider.js
+++ b/src/providers/BlockHashProvider/BlockHashProvider.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useState} from 'react';
 
 import {useConfig} from '../../hooks';
-import {starknet} from '../../libs';
+import {getStarknet} from '../../libs';
 import {BlockHashContext} from './block-hash-context';
 
 export const BlockHashProvider = ({children}) => {
@@ -10,7 +10,7 @@ export const BlockHashProvider = ({children}) => {
   const [blockHash, setBlockHash] = useState();
 
   const fetchBlockHash = useCallback(async () => {
-    const {block_hash} = await starknet.defaultProvider.getBlock();
+    const {block_hash} = await getStarknet().provider.getBlock();
     setBlockHash(block_hash);
   }, []);
 

--- a/src/providers/TransfersLogProvider/TransfersLogProvider.js
+++ b/src/providers/TransfersLogProvider/TransfersLogProvider.js
@@ -5,7 +5,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import envs from '../../config/envs';
 import {isCompleted, isConsumed} from '../../enums';
 import {useLogger} from '../../hooks';
-import {starknet} from '../../libs';
+import {getStarknet} from '../../libs';
 import utils from '../../utils';
 import {useBlockHash} from '../BlockHashProvider';
 import {useTokens} from '../TokensProvider';
@@ -38,7 +38,7 @@ export const TransfersLogProvider = ({children}) => {
         }
         try {
           logger.log(`Checking tx status ${transfer.l2hash}`);
-          const {tx_status} = await starknet.defaultProvider.getTransactionStatus(transfer.l2hash);
+          const {tx_status} = await getStarknet().provider.getTransactionStatus(transfer.l2hash);
           if (transfer.status !== tx_status) {
             logger.log(`Status changed from ${transfer.status}->${tx_status}`);
           } else {

--- a/src/utils/blockchain/starknet.js
+++ b/src/utils/blockchain/starknet.js
@@ -1,7 +1,7 @@
 import {ChainInfo, isRejected, TransactionStatusStep} from '../../enums';
 import {getStarknet, starknet} from '../../libs';
 
-const {Contract, defaultProvider, stark, hash, number} = starknet;
+const {Contract, stark, hash, number} = starknet;
 
 export const createContract = (address, ABI) => {
   return new Contract(ABI, address, getStarknet().provider);
@@ -34,7 +34,7 @@ export const waitForTransaction = async (transactionHash, requiredStatus, retryI
     let processing = false;
     const intervalId = setInterval(async () => {
       if (processing) return;
-      const statusPromise = defaultProvider.getTransactionStatus(transactionHash);
+      const statusPromise = getStarknet().provider.getTransactionStatus(transactionHash);
       processing = true;
       try {
         const {tx_status} = await statusPromise;


### PR DESCRIPTION
### Description of the Changes

`defaultProvider` by default is working against Goerli testnet. 
For mainnet envs we should work with the wallet provider (i.e. `getStarknet().provider`).

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/170)
<!-- Reviewable:end -->
