### PR TITLE
fix: cancel toFixed when format balances

### DIFF
--- a/src/__tests__/utils/wallet.spec.js
+++ b/src/__tests__/utils/wallet.spec.js
@@ -44,6 +44,6 @@ describe('shortenBalance', () => {
 
   it('should return the same balance for short balance', () => {
     expect(shortenBalance('0.00001')).toEqual('0.00001');
-    expect(shortenBalance(0.123)).toEqual('0.123');
+    expect(shortenBalance(0.123)).toEqual(0.123);
   });
 });

--- a/src/__tests__/utils/wallet.spec.js
+++ b/src/__tests__/utils/wallet.spec.js
@@ -3,10 +3,10 @@ import utils from '../../utils';
 const {formatBalance, shortenAddress, shortenBalance} = utils.wallet;
 
 describe('formatBalance', () => {
-  it('should format balance to 5 digits precision', () => {
-    expect(formatBalance(1.222243232)).toEqual(1.22224);
-    expect(formatBalance(3000.232143123212)).toEqual(3000.23214);
-    expect(formatBalance(10.000000001)).toEqual(10);
+  it('should format balance as string', () => {
+    expect(formatBalance(1.222243232)).toEqual('1.222243232');
+    expect(formatBalance(3000.232143123212)).toEqual('3000.232143123212');
+    expect(formatBalance(10.000000001)).toEqual('10.000000001');
   });
 
   it('should handle exponential balances', () => {
@@ -44,6 +44,6 @@ describe('shortenBalance', () => {
 
   it('should return the same balance for short balance', () => {
     expect(shortenBalance('0.00001')).toEqual('0.00001');
-    expect(shortenBalance(0.123)).toEqual(0.123);
+    expect(shortenBalance(0.123)).toEqual('0.123');
   });
 });

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -1,9 +1,5 @@
 export const formatBalance = balance => {
-  if (typeof balance === 'number') {
-    balance = fromExponential(balance);
-    return typeof balance === 'string' ? balance : parseFloat(balance.toFixed(5));
-  }
-  return 'N/A';
+  return typeof balance === 'number' ? String(fromExponential(balance)) : 'N/A';
 };
 
 export const shortenBalance = balance => {


### PR DESCRIPTION
### Description of the Changes

Issue: when the balance is zero with more than 5 digits after the dot (i.e. 0.0000001) balance is shown as 0.
Solution: transform the displayed balances to strings and format their display to `0.00000...` in such cases.

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/172)
<!-- Reviewable:end -->
