### PR TITLE
fix: connection modal overrides gsw selection modal

### DIFF
--- a/src/libs/starknet.js
+++ b/src/libs/starknet.js
@@ -1,4 +1,4 @@
-import {getStarknet} from 'get-starknet-wallet';
+import {getStarknet, connect as getStarknetWallet} from 'get-starknet-wallet';
 import * as starknet from 'starknet';
 
-export {starknet, getStarknet};
+export {starknet, getStarknet, getStarknetWallet};

--- a/src/providers/WalletsProvider/wallets-hooks.js
+++ b/src/providers/WalletsProvider/wallets-hooks.js
@@ -2,7 +2,7 @@ import {useCallback, useContext, useEffect, useState} from 'react';
 
 import {ChainInfo, ChainType, WalletErrorType, WalletStatus} from '../../enums';
 import {useEnvs} from '../../hooks';
-import {getStarknet} from '../../libs';
+import {getStarknet, getStarknetWallet} from '../../libs';
 import {useTransfer} from '../TransferProvider';
 import {WalletsContext} from './wallets-context';
 
@@ -70,8 +70,11 @@ export const useStarknetWallet = () => {
 
   const connect = async walletConfig => {
     try {
+      const wallet = await getStarknetWallet();
+      if (!wallet) {
+        return;
+      }
       setStatus(WalletStatus.CONNECTING);
-      const wallet = getStarknet();
       const enabled = await wallet
         .enable(!autoConnect && {showModal: true})
         .then(address => !!address?.length);


### PR DESCRIPTION
### Description of the Changes

Issue:
In case the user selected a wallet but the wallet is locked or the dapp is not connected (i.e. not yet authorized), the promise will not be resolved. so I don't have a way to differentiate between the selection of the wallet and the actual connection to the wallet

Solution: 
Use `connect` API from `get-starknet-wallet` which returns the actual selected wallet from the list 

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/175)
<!-- Reviewable:end -->
