### PR TITLE
fix: CompleteTransferToL1 toast remains on display after tx is done

### DIFF
--- a/src/components/Features/ToastProvider/ToastProvider.js
+++ b/src/components/Features/ToastProvider/ToastProvider.js
@@ -55,7 +55,7 @@ export const ToastProvider = () => {
   };
 
   const handleToast = (transfer, prevTransfer) => {
-    const {status, type} = transfer;
+    const {status, type, l1hash} = transfer;
     const isChanged = prevTransfer && status !== prevTransfer.status;
     if (isChanged && isConsumed(status)) {
       return showConsumedTransferToast(transfer);
@@ -64,10 +64,10 @@ export const ToastProvider = () => {
       return showRejectedTransferToast(transfer);
     }
     if (type === ActionType.TRANSFER_TO_L1) {
-      if (!transfer.l1hash && isOnChain(status)) {
+      if (!l1hash && isOnChain(status)) {
         return showCompleteTransferToL1Toast(transfer);
       }
-      if (transfer.l1hash && isToastRendered(transfer.id, ToastType.COMPLETE_TRANSFER_TO_L1)) {
+      if (l1hash && isToastRendered(transfer.id, ToastType.COMPLETE_TRANSFER_TO_L1)) {
         return dismissToast(transfer.id, ToastType.COMPLETE_TRANSFER_TO_L1);
       }
     }

--- a/src/components/Features/ToastProvider/ToastProvider.js
+++ b/src/components/Features/ToastProvider/ToastProvider.js
@@ -40,15 +40,19 @@ export const ToastProvider = () => {
   }, [breakpoint]);
 
   useDeepCompareEffect(() => {
-    transfers.forEach(transfer => {
-      const prevTransfer = prevTransfers?.find(prevTransfer => prevTransfer.id === transfer.id);
-      handleToast(transfer, prevTransfer);
-    });
+    renderToasts();
   }, [transfers]);
 
   useEffect(() => {
     return () => clearToasts();
   }, []);
+
+  const renderToasts = () => {
+    transfers.forEach(transfer => {
+      const prevTransfer = prevTransfers?.find(prevTransfer => prevTransfer.id === transfer.id);
+      handleToast(transfer, prevTransfer);
+    });
+  };
 
   const handleToast = (transfer, prevTransfer) => {
     const {status, type} = transfer;
@@ -59,8 +63,13 @@ export const ToastProvider = () => {
     if (isChanged && isRejected(status)) {
       return showRejectedTransferToast(transfer);
     }
-    if (!transfer.l1hash && type === ActionType.TRANSFER_TO_L1 && isOnChain(status)) {
-      return showCompleteTransferToL1Toast(transfer);
+    if (type === ActionType.TRANSFER_TO_L1) {
+      if (!transfer.l1hash && isOnChain(status)) {
+        return showCompleteTransferToL1Toast(transfer);
+      }
+      if (transfer.l1hash && isToastRendered(transfer.id, ToastType.COMPLETE_TRANSFER_TO_L1)) {
+        return dismissToast(transfer.id, ToastType.COMPLETE_TRANSFER_TO_L1);
+      }
     }
   };
 


### PR DESCRIPTION
### Description of the Changes

Dismiss programmatically if the `l1hash` prop exists on `transfer` object and this toast is rendered before the re-render. 

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/179)
<!-- Reviewable:end -->
