### PR TITLE
fix: move EventManagerProvider to app-level

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -15,3 +15,4 @@ export * from './useConstants';
 export * from './useTranslation';
 export * from './useTracking';
 export * from './useBuyProviders';
+export * from './useAccountChange';

--- a/src/hooks/useAccountChange.js
+++ b/src/hooks/useAccountChange.js
@@ -1,0 +1,13 @@
+import {useEffect} from 'react';
+
+import {useAccountHash} from '../providers/WalletsProvider';
+
+export const useAccountChange = fn => {
+  const accountHash = useAccountHash();
+
+  useEffect(() => {
+    if (accountHash) {
+      fn();
+    }
+  }, [accountHash]);
+};

--- a/src/providers/EventManagerProvider/EventManagerProvider.js
+++ b/src/providers/EventManagerProvider/EventManagerProvider.js
@@ -4,28 +4,29 @@ import React, {useEffect} from 'react';
 import {EventName, SelectorName} from '../../enums';
 import {useL1TokenBridgeContract, useLogger} from '../../hooks';
 import {starknet} from '../../libs';
-import {parseToFelt} from '../../utils/parser';
+import {parseToFelt} from '../../utils';
 import {useL1Tokens, useL2Tokens} from '../TokensProvider';
-import {useL1Wallet, useL2Wallet} from '../WalletsProvider';
+import {useAccountHash, useL1Wallet, useL2Wallet} from '../WalletsProvider';
 import {EventManagerContext} from './event-manager-context';
 
 const listeners = {};
 const filters = {};
-let emitters = [];
 
 export const EventManagerProvider = ({children}) => {
   const logger = useLogger(EventManagerProvider.displayName);
   const getTokenBridgeContract = useL1TokenBridgeContract();
   const {account: l1Account} = useL1Wallet();
   const {account: l2Account} = useL2Wallet();
+  const accountHash = useAccountHash();
   const l1Tokens = useL1Tokens();
   const l2Tokens = useL2Tokens();
 
   useEffect(() => {
-    setEventFilters();
-    addDepositWithdrawalListeners();
-    return () => cleanEmittersAndRemoveListeners();
-  }, []);
+    if (accountHash) {
+      setEventFilters();
+      addListeners();
+    }
+  }, [accountHash]);
 
   const addListener = (eventName, callback) => {
     logger.log(`Registered to ${eventName} event.`);
@@ -62,7 +63,7 @@ export const EventManagerProvider = ({children}) => {
     emitListeners(EventName.L1.LOG_DEPOSIT, error, event);
   };
 
-  const addDepositWithdrawalListeners = () => {
+  const addListeners = () => {
     l1Tokens.forEach(l1Token => {
       const bridgeContract = getTokenBridgeContract(l1Token.bridgeAddress);
       logger.log(`Add ${EventName.L1.LOG_DEPOSIT} listener for token ${l1Token.symbol}.`);
@@ -103,21 +104,12 @@ export const EventManagerProvider = ({children}) => {
   };
 
   const addContractEventListener = (contract, eventName, filter, handler) => {
-    emitters.push(
-      contract.events[eventName](
-        {
-          filter
-        },
-        handler
-      )
+    contract.events[eventName](
+      {
+        filter
+      },
+      handler
     );
-  };
-
-  const cleanEmittersAndRemoveListeners = () => {
-    logger.log('Remove all listeners.');
-    emitters.forEach(emitter => emitter.removeAllListeners());
-    logger.log('Clean emitters.');
-    emitters = [];
   };
 
   const value = {

--- a/src/providers/EventManagerProvider/EventManagerProvider.js
+++ b/src/providers/EventManagerProvider/EventManagerProvider.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
-import React, {useEffect} from 'react';
+import React from 'react';
 
 import {EventName, SelectorName} from '../../enums';
-import {useL1TokenBridgeContract, useLogger} from '../../hooks';
+import {useAccountChange, useL1TokenBridgeContract, useLogger} from '../../hooks';
 import {starknet} from '../../libs';
 import {parseToFelt} from '../../utils';
 import {useL1Tokens, useL2Tokens} from '../TokensProvider';
-import {useAccountHash, useL1Wallet, useL2Wallet} from '../WalletsProvider';
+import {useL1Wallet, useL2Wallet} from '../WalletsProvider';
 import {EventManagerContext} from './event-manager-context';
 
 const listeners = {};
@@ -17,16 +17,13 @@ export const EventManagerProvider = ({children}) => {
   const getTokenBridgeContract = useL1TokenBridgeContract();
   const {account: l1Account} = useL1Wallet();
   const {account: l2Account} = useL2Wallet();
-  const accountHash = useAccountHash();
   const l1Tokens = useL1Tokens();
   const l2Tokens = useL2Tokens();
 
-  useEffect(() => {
-    if (accountHash) {
-      setEventFilters();
-      addListeners();
-    }
-  }, [accountHash]);
+  useAccountChange(() => {
+    setEventFilters();
+    addListeners();
+  });
 
   const addListener = (eventName, callback) => {
     logger.log(`Registered to ${eventName} event.`);

--- a/src/providers/TokensProvider/TokensProvider.js
+++ b/src/providers/TokensProvider/TokensProvider.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import React, {useEffect, useReducer} from 'react';
+import React, {useReducer} from 'react';
 
-import {useConstants, useLogger} from '../../hooks';
+import {useAccountChange, useConstants, useLogger} from '../../hooks';
 import {useL1TokenBalance, useL2TokenBalance} from '../../hooks/useTokenBalance';
-import {useAccountHash, useL1Wallet, useL2Wallet} from '../WalletsProvider';
+import {useL1Wallet, useL2Wallet} from '../WalletsProvider';
 import {TokensContext} from './tokens-context';
 import {actions, initialState, reducer} from './tokens-reducer';
 
@@ -13,15 +13,12 @@ export const TokensProvider = ({children}) => {
   const [tokens, dispatch] = useReducer(reducer, initialState);
   const {account: l1Account} = useL1Wallet();
   const {account: l2Account} = useL2Wallet();
-  const accountHash = useAccountHash();
   const getL1TokenBalance = useL1TokenBalance(l1Account);
   const getL2TokenBalance = useL2TokenBalance(l2Account);
 
-  useEffect(() => {
-    if (accountHash) {
-      fetchBalances(tokens);
-    }
-  }, [accountHash]);
+  useAccountChange(() => {
+    fetchBalances(tokens);
+  });
 
   const updateTokenBalance = symbol => {
     logger.log(symbol ? `Update ${symbol} token balance` : 'Update all tokens balances');

--- a/src/providers/TokensProvider/TokensProvider.js
+++ b/src/providers/TokensProvider/TokensProvider.js
@@ -3,7 +3,7 @@ import React, {useEffect, useReducer} from 'react';
 
 import {useConstants, useLogger} from '../../hooks';
 import {useL1TokenBalance, useL2TokenBalance} from '../../hooks/useTokenBalance';
-import {useL1Wallet, useL2Wallet} from '../WalletsProvider';
+import {useAccountHash, useL1Wallet, useL2Wallet} from '../WalletsProvider';
 import {TokensContext} from './tokens-context';
 import {actions, initialState, reducer} from './tokens-reducer';
 
@@ -13,12 +13,15 @@ export const TokensProvider = ({children}) => {
   const [tokens, dispatch] = useReducer(reducer, initialState);
   const {account: l1Account} = useL1Wallet();
   const {account: l2Account} = useL2Wallet();
+  const accountHash = useAccountHash();
   const getL1TokenBalance = useL1TokenBalance(l1Account);
   const getL2TokenBalance = useL2TokenBalance(l2Account);
 
   useEffect(() => {
-    fetchBalances(tokens);
-  }, []);
+    if (accountHash) {
+      fetchBalances(tokens);
+    }
+  }, [accountHash]);
 
   const updateTokenBalance = symbol => {
     logger.log(symbol ? `Update ${symbol} token balance` : 'Update all tokens balances');

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -17,11 +17,8 @@ export const AppProviders = combineProviders([
   ModalProvider,
   WalletProvider,
   WalletsProvider,
-  BlockHashProvider
+  TokensProvider,
+  EventManagerProvider
 ]);
 
-export const BridgeProviders = combineProviders([
-  TokensProvider,
-  EventManagerProvider,
-  TransfersLogProvider
-]);
+export const BridgeProviders = combineProviders([BlockHashProvider, TransfersLogProvider]);


### PR DESCRIPTION
### Description of the Changes

Move `EventManagerProvider` to app-level to avoid re-rendering when visiting non-bridge pages.

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/197)
<!-- Reviewable:end -->
