### PR TITLE
fix(2918898444): Too many zeros shows for WBTC

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@metamask/onboarding": "^1.0.1",
     "@mui/material": "^5.5.3",
     "@mui/styles": "^5.5.0",
+    "@normalizex/ethjs-unit": "^0.1.8",
     "@splitbee/web": "^0.3.0",
     "get-starknet": "^1.4.2",
     "js-logger": "^1.6.1",

--- a/src/__tests__/utils/parser.spec.js
+++ b/src/__tests__/utils/parser.spec.js
@@ -3,8 +3,7 @@ import {
   parseFromFelt,
   parseFromUint256,
   parseToDecimals,
-  parseToUint256,
-  UNIT_MAP
+  parseToUint256
 } from '../../utils';
 
 describe('parseToDecimals', () => {
@@ -69,8 +68,8 @@ describe('parseFromUint256', () => {
     expect(parseFromUint256({high: '0x0', low: '0x21e19e0c9bab2400000', type: 'struct'})).toEqual(
       10000
     );
-    expect(
-      parseFromUint256({high: '0x0', low: '0x84595161401484a000000', type: 'struct'})
-    ).toEqual(10000000);
+    expect(parseFromUint256({high: '0x0', low: '0x84595161401484a000000', type: 'struct'})).toEqual(
+      10000000
+    );
   });
 });

--- a/src/__tests__/utils/parser.spec.js
+++ b/src/__tests__/utils/parser.spec.js
@@ -7,87 +7,70 @@ import {
   UNIT_MAP
 } from '../../utils';
 
-describe('UNIT_MAP', () => {
-  it('should init unit map', () => {
-    expect(UNIT_MAP).toEqual({
-      0: 'noether',
-      1: 'wei',
-      1000: 'femtoether',
-      1000000: 'picoether',
-      1000000000: 'nano',
-      1000000000000: 'micro',
-      1000000000000000: 'milli',
-      1000000000000000000: 'ether',
-      '1000000000000000000000': 'grand',
-      '1000000000000000000000000': 'mether',
-      '1000000000000000000000000000': 'gether',
-      '1000000000000000000000000000000': 'tether'
+describe('parseToDecimals', () => {
+  it('should parse to decimals', () => {
+    expect(parseToDecimals('1')).toEqual('1000000000000000000');
+    expect(parseToDecimals('1', 3)).toEqual('1000');
+    expect(parseToDecimals('1', 6)).toEqual('1000000');
+    expect(parseToDecimals('1', 8)).toEqual('100000000');
+    expect(parseToDecimals('1', 9)).toEqual('1000000000');
+    expect(parseToDecimals('1', 12)).toEqual('1000000000000');
+    expect(parseToDecimals('1', 15)).toEqual('1000000000000000');
+    expect(parseToDecimals('1', 18)).toEqual('1000000000000000000');
+  });
+});
+
+describe('parseFromDecimals', () => {
+  it('should parse from decimals', () => {
+    expect(parseFromDecimals('1000000000000000000')).toEqual(1);
+    expect(parseFromDecimals('1000000000000000000', 3)).toEqual(1000000000000000);
+    expect(parseFromDecimals('1000000000000000000', 6)).toEqual(1000000000000);
+    expect(parseFromDecimals('1000000000000000000', 8)).toEqual(10000000000);
+    expect(parseFromDecimals('1000000000000000000', 9)).toEqual(1000000000);
+    expect(parseFromDecimals('1000000000000000000', 12)).toEqual(1000000);
+    expect(parseFromDecimals('1000000000000000000', 15)).toEqual(1000);
+    expect(parseFromDecimals('1000000000000000000', 18)).toEqual(1);
+  });
+});
+
+describe('parseFromFelt', () => {
+  it('should parse from felt', () => {
+    expect(parseFromFelt('0x1')).toEqual(1);
+    expect(parseFromFelt('0x10')).toEqual(16);
+    expect(parseFromFelt('0x100')).toEqual(256);
+  });
+});
+
+describe('parseToUint256', () => {
+  it('should parse to uint256', () => {
+    expect(parseToUint256('100')).toEqual({
+      high: '0x0',
+      low: '0x56bc75e2d63100000',
+      type: 'struct'
+    });
+    expect(parseToUint256('10000')).toEqual({
+      high: '0x0',
+      low: '0x21e19e0c9bab2400000',
+      type: 'struct'
+    });
+    expect(parseToUint256('10000000')).toEqual({
+      high: '0x0',
+      low: '0x84595161401484a000000',
+      type: 'struct'
     });
   });
+});
 
-  describe('parseToDecimals', () => {
-    it('should parse to decimals', () => {
-      expect(parseToDecimals('1')).toEqual('1000000000000000000');
-      expect(parseToDecimals('1', 3)).toEqual('1000');
-      expect(parseToDecimals('1', 6)).toEqual('1000000');
-      expect(parseToDecimals('1', 9)).toEqual('1000000000');
-      expect(parseToDecimals('1', 12)).toEqual('1000000000000');
-      expect(parseToDecimals('1', 15)).toEqual('1000000000000000');
-      expect(parseToDecimals('1', 18)).toEqual('1000000000000000000');
-    });
-  });
-
-  describe('parseFromDecimals', () => {
-    it('should parse from decimals', () => {
-      expect(parseFromDecimals('1000000000000000000')).toEqual(1);
-      expect(parseFromDecimals('1000000000000000000', 3)).toEqual(1000000000000000);
-      expect(parseFromDecimals('1000000000000000000', 6)).toEqual(1000000000000);
-      expect(parseFromDecimals('1000000000000000000', 9)).toEqual(1000000000);
-      expect(parseFromDecimals('1000000000000000000', 12)).toEqual(1000000);
-      expect(parseFromDecimals('1000000000000000000', 15)).toEqual(1000);
-      expect(parseFromDecimals('1000000000000000000', 18)).toEqual(1);
-    });
-  });
-
-  describe('parseFromFelt', () => {
-    it('should parse from felt', () => {
-      expect(parseFromFelt('0x1')).toEqual(1);
-      expect(parseFromFelt('0x10')).toEqual(16);
-      expect(parseFromFelt('0x100')).toEqual(256);
-    });
-  });
-
-  describe('parseToUint256', () => {
-    it('should parse to uint256', () => {
-      expect(parseToUint256('100')).toEqual({
-        high: '0x0',
-        low: '0x56bc75e2d63100000',
-        type: 'struct'
-      });
-      expect(parseToUint256('10000')).toEqual({
-        high: '0x0',
-        low: '0x21e19e0c9bab2400000',
-        type: 'struct'
-      });
-      expect(parseToUint256('10000000')).toEqual({
-        high: '0x0',
-        low: '0x84595161401484a000000',
-        type: 'struct'
-      });
-    });
-  });
-
-  describe('parseFromUint256', () => {
-    it('should parse from uint256', () => {
-      expect(parseFromUint256({high: '0x0', low: '0x56bc75e2d63100000', type: 'struct'})).toEqual(
-        100
-      );
-      expect(parseFromUint256({high: '0x0', low: '0x21e19e0c9bab2400000', type: 'struct'})).toEqual(
-        10000
-      );
-      expect(
-        parseFromUint256({high: '0x0', low: '0x84595161401484a000000', type: 'struct'})
-      ).toEqual(10000000);
-    });
+describe('parseFromUint256', () => {
+  it('should parse from uint256', () => {
+    expect(parseFromUint256({high: '0x0', low: '0x56bc75e2d63100000', type: 'struct'})).toEqual(
+      100
+    );
+    expect(parseFromUint256({high: '0x0', low: '0x21e19e0c9bab2400000', type: 'struct'})).toEqual(
+      10000
+    );
+    expect(
+      parseFromUint256({high: '0x0', low: '0x84595161401484a000000', type: 'struct'})
+    ).toEqual(10000000);
   });
 });

--- a/src/__tests__/utils/parser.spec.js
+++ b/src/__tests__/utils/parser.spec.js
@@ -21,14 +21,14 @@ describe('parseToDecimals', () => {
 
 describe('parseFromDecimals', () => {
   it('should parse from decimals', () => {
-    expect(parseFromDecimals('1000000000000000000')).toEqual(1);
-    expect(parseFromDecimals('1000000000000000000', 3)).toEqual(1000000000000000);
-    expect(parseFromDecimals('1000000000000000000', 6)).toEqual(1000000000000);
-    expect(parseFromDecimals('1000000000000000000', 8)).toEqual(10000000000);
-    expect(parseFromDecimals('1000000000000000000', 9)).toEqual(1000000000);
-    expect(parseFromDecimals('1000000000000000000', 12)).toEqual(1000000);
-    expect(parseFromDecimals('1000000000000000000', 15)).toEqual(1000);
-    expect(parseFromDecimals('1000000000000000000', 18)).toEqual(1);
+    expect(parseFromDecimals('1000000000000000000')).toEqual('1');
+    expect(parseFromDecimals('1000000000000000000', 3)).toEqual('1000000000000000');
+    expect(parseFromDecimals('1000000000000000000', 6)).toEqual('1000000000000');
+    expect(parseFromDecimals('1000000000000000000', 8)).toEqual('10000000000');
+    expect(parseFromDecimals('1000000000000000000', 9)).toEqual('1000000000');
+    expect(parseFromDecimals('1000000000000000000', 12)).toEqual('1000000');
+    expect(parseFromDecimals('1000000000000000000', 15)).toEqual('1000');
+    expect(parseFromDecimals('1000000000000000000', 18)).toEqual('1');
   });
 });
 
@@ -63,13 +63,13 @@ describe('parseToUint256', () => {
 describe('parseFromUint256', () => {
   it('should parse from uint256', () => {
     expect(parseFromUint256({high: '0x0', low: '0x56bc75e2d63100000', type: 'struct'})).toEqual(
-      100
+      '100'
     );
     expect(parseFromUint256({high: '0x0', low: '0x21e19e0c9bab2400000', type: 'struct'})).toEqual(
-      10000
+      '10000'
     );
     expect(parseFromUint256({high: '0x0', low: '0x84595161401484a000000', type: 'struct'})).toEqual(
-      10000000
+      '10000000'
     );
   });
 });

--- a/src/__tests__/utils/wallet.spec.js
+++ b/src/__tests__/utils/wallet.spec.js
@@ -2,13 +2,9 @@ import {formatBalance, shortenAddress, shortenBalance} from '../../utils';
 
 describe('formatBalance', () => {
   it('should format balance as string', () => {
-    expect(formatBalance(1.222243232)).toEqual('1.222243232');
-    expect(formatBalance(3000.232143123212)).toEqual('3000.232143123212');
-    expect(formatBalance(10.000000001)).toEqual('10.000000001');
-  });
-
-  it('should handle exponential balances', () => {
-    expect(formatBalance(1.02e-9)).toEqual('0.00000000102');
+    expect(formatBalance('1.222243232')).toEqual('1.222243232');
+    expect(formatBalance('3000.232143123212')).toEqual('3000.232143123212');
+    expect(formatBalance('10.000000001')).toEqual('10.000000001');
   });
 
   it('should return N/A for non-numbers', () => {

--- a/src/components/Features/Transfer/Transfer.js
+++ b/src/components/Features/Transfer/Transfer.js
@@ -90,9 +90,9 @@ export const Transfer = () => {
       errorMsg = tooManyDigitsErrorMsg;
     } else if (isNegative(amount)) {
       errorMsg = negativeValueErrorMsg;
-    } else if (amount > balance) {
+    } else if (Number(amount) > Number(balance)) {
       errorMsg = insufficientBalanceErrorMsg;
-    } else if (isL1 && amount > maxDeposit) {
+    } else if (isL1 && Number(amount) > Number(maxDeposit)) {
       errorMsg = evaluate(maxDepositErrorMsg, {maxDeposit, symbol});
     }
 

--- a/src/hooks/useIsMaxTotalBalanceExceeded.js
+++ b/src/hooks/useIsMaxTotalBalanceExceeded.js
@@ -13,10 +13,11 @@ export const useIsMaxTotalBalanceExceeded = () => {
       if (selectedToken && isL1) {
         const {maxTotalBalance} = selectedToken;
         const currentTotalBalance = await getTokenBridgeBalance(selectedToken);
+        const exceeded = Number(maxTotalBalance) <= Number(currentTotalBalance) + Number(amount);
         return {
           maxTotalBalance,
           currentTotalBalance,
-          exceeded: maxTotalBalance <= currentTotalBalance + Number(amount)
+          exceeded
         };
       }
       return {exceeded: false};

--- a/src/hooks/useTransferToL2.js
+++ b/src/hooks/useTransferToL2.js
@@ -111,7 +111,7 @@ export const useTransferToL2 = () => {
               spender: bridgeAddress
             });
             logger.log('Current allow value', {allow});
-            if (allow < amount) {
+            if (Number(allow) < Number(amount)) {
               logger.log('Allow value is smaller then amount, sending approve tx...', {amount});
               await approve({
                 spender: bridgeAddress,

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -1,22 +1,16 @@
-import {web3, starknet} from '../libs';
+import {starknet} from '../libs';
 
 const {number, uint256} = starknet;
-const {utils} = web3;
 
 const TEN = 10;
 const DEFAULT_DECIMALS = 18;
-export const UNIT_MAP = {};
-
-for (const key in utils.unitMap) {
-  UNIT_MAP[utils.unitMap[key]] = key;
-}
 
 export const parseToDecimals = (value, decimals = DEFAULT_DECIMALS) => {
-  return utils.toWei(value, UNIT_MAP[Math.pow(TEN, decimals)]);
+  return String(value * Math.pow(TEN, decimals));
 };
 
 export const parseFromDecimals = (value, decimals = DEFAULT_DECIMALS) => {
-  return Number(utils.fromWei(value, UNIT_MAP[Math.pow(TEN, decimals)]));
+  return value / Math.pow(TEN, decimals);
 };
 
 export const parseFromFelt = value => {

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -1,16 +1,17 @@
+import {fromWeiByDecimals, toWeiByDecimals} from '@normalizex/ethjs-unit';
+
 import {starknet} from '../libs';
 
 const {number, uint256} = starknet;
 
-const TEN = 10;
 const DEFAULT_DECIMALS = 18;
 
 export const parseToDecimals = (value, decimals = DEFAULT_DECIMALS) => {
-  return String(value * Math.pow(TEN, decimals));
+  return toWeiByDecimals(value, decimals);
 };
 
 export const parseFromDecimals = (value, decimals = DEFAULT_DECIMALS) => {
-  return value / Math.pow(TEN, decimals);
+  return fromWeiByDecimals(value, decimals);
 };
 
 export const parseFromFelt = value => {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -2,7 +2,7 @@ import {starknet} from '../libs';
 import {parseToFelt} from './parser';
 
 export const formatBalance = balance => {
-  return typeof balance === 'number' ? String(fromExponential(balance)) : 'N/A';
+  return balance || 'N/A';
 };
 
 export const shortenBalance = balance => {
@@ -22,22 +22,4 @@ export const calcAccountHash = (account1, account2) => {
     parseToFelt(account1).toString(),
     parseToFelt(account2).toString()
   ]);
-};
-
-const fromExponential = x => {
-  if (Math.abs(x) < 1.0) {
-    const e = parseInt(x.toString().split('e-')[1]);
-    if (e) {
-      x *= Math.pow(10, e - 1);
-      x = `0.${new Array(e).join('0')}${x.toString().substring(2)}`;
-    }
-  } else {
-    let e = parseInt(x.toString().split('+')[1]);
-    if (e > 20) {
-      e -= 20;
-      x /= Math.pow(10, e);
-      x += new Array(e + 1).join('0');
-    }
-  }
-  return x;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2807,6 +2807,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@normalizex/ethjs-unit@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@normalizex/ethjs-unit/-/ethjs-unit-0.1.8.tgz#539af34d25ee023d96087d2193d4af4aef03fd7e"
+  integrity sha512-oAh+RS0x/0vRtSVxvhHxt+RrYayH1znj3w1096Vc2pw+eAuYHB4ePU9IYVGu4doz/qHuyaTzaQ73hgWFEw+jUg==
+  dependencies:
+    bn.js "4.11.6"
+
 "@npmcli/arborist@^5.0.0", "@npmcli/arborist@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@npmcli/arborist/-/arborist-5.0.3.tgz#3ba8e0a357eaf6e1c56d44b7379214079e57a05b"


### PR DESCRIPTION
### Description of the Changes

Used the unit map of `web3` to do the conversions.
The problem is that in this map the jumps are in 3 decimals, I.e. 3,6,9,12,18...
So if we have a token with 8 decimals, for example, we didn't convert him correctly.

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/228)
<!-- Reviewable:end -->
