### PR TITLE
fix(2878552430): User routes to the main screen even if not choose an L2 wallet

### DIFF
--- a/src/providers/WalletsProvider/wallets-hooks.js
+++ b/src/providers/WalletsProvider/wallets-hooks.js
@@ -78,7 +78,7 @@ export const useStarknetWallet = () => {
       setStatus(WalletStatus.CONNECTING);
       const enabled = await wallet
         .enable(!autoConnect && {showModal: true})
-        .then(address => !!address?.length);
+        .then(address => address?.length && address[0]);
       if (enabled) {
         updateAccount();
         addAccountChangedListener();


### PR DESCRIPTION
### Description of the Changes

This fix is for a scenario where the user closes the popup window of the wallet connection and goes into the main application screen. the solution is to add another check in the if statement which checks that the address that we receiving from the `get-starknet` library is something not falsy (in our case is an empty string)

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/232)
<!-- Reviewable:end -->
