### PR TITLE
chore: move app urls to constants.js

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,4 @@
 REACT_APP_NAME=$npm_package_name
 REACT_APP_VERSION=$npm_package_version
-REACT_APP_URL_GOERLI=https://goerli.starkgate.starknet.io
-REACT_APP_URL_DEVNET=https://devnet-goerli.starkgate.starknet.io
-REACT_APP_URL_MAINNET=https://starkgate.starknet.io
 REACT_APP_LOCAL_STORAGE_TRANSFERS_LOG_KEY=STARKGATE_TRANSFERS
 REACT_APP_LOCAL_STORAGE_ACCEPT_TERMS=STARKGATE_ACCEPT_TERMS

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -18,3 +18,5 @@ export const FEEDBACK_FORM_URL_MAINNET =
 export const ONBOARDING_COOKIE_NAME = 'sg_onboard_modal';
 export const ALPHA_DISCLAIMER_COOKIE_NAME = 'sg_alpha_toast';
 export const HIDE_ELEMENT_COOKIE_DURATION_DAYS = 1;
+export const APP_URL_GOERLI = 'https://goerli.starkgate.starknet.io';
+export const APP_URL_MAINNET = 'https://starkgate.starknet.io';

--- a/src/enums/ChainType.js
+++ b/src/enums/ChainType.js
@@ -1,3 +1,5 @@
+import {APP_URL_MAINNET, APP_URL_GOERLI} from '../config/constants';
+
 export const ChainType = {
   L1: {
     MAIN: 1,
@@ -23,13 +25,13 @@ export const ChainInfo = {
       CHAIN: 'Mainnet',
       NAME: 'StarkNet Mainnet',
       ID_PREFIX: '23448594291968334',
-      APP_URL: process.env.REACT_APP_URL_MAINNET
+      APP_URL: APP_URL_MAINNET
     },
     [ChainType.L2.GOERLI]: {
       CHAIN: 'Goerli',
       NAME: 'StarkNet Goerli',
       ID_PREFIX: '1536727068981429685321',
-      APP_URL: process.env.REACT_APP_URL_GOERLI
+      APP_URL: APP_URL_GOERLI
     }
   }
 };


### PR DESCRIPTION
### Description of the Changes

move `APP_URL_GOERLI` and `APP_URL_MAINNET` from .env to constants.js

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/247)
<!-- Reviewable:end -->
