### PR TITLE
fix(3080263579): While error is raised when connecting to the wallet, modal isn't shown again

### DIFF
--- a/src/components/UI/NetworkWalletButton/NetworkWalletButton.js
+++ b/src/components/UI/NetworkWalletButton/NetworkWalletButton.js
@@ -18,6 +18,7 @@ export const NetworkWalletButton = ({account, chain, logoPath, network, status, 
 
   const handleWalletButtonClick = () => {
     switch (status) {
+      case WalletStatus.ERROR:
       case WalletStatus.CONNECTING:
       case WalletStatus.DISCONNECTED:
         return handleConnectWallet();


### PR DESCRIPTION
### Description of the Changes

Call wallet connect handler while wallet status is `WalletStatus.ERROR`.

### Checklist

- [ ] Changes have been done against master branch, and PR does not conflict
- [ ] New unit / functional tests have been added (whenever applicable)
- [ ] Test are passing in local environment
- [ ] Docs have been updated
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/268)
<!-- Reviewable:end -->
