### PR TITLE
fix(3155991918): redundant purple border on Discord button

### DIFF
--- a/src/components/UI/SideButton/SideButton.module.scss
+++ b/src/components/UI/SideButton/SideButton.module.scss
@@ -6,7 +6,6 @@
   right: 0;
   transform: translateY(-50%);
   background: $--color-orange-soda;
-  border: 1px solid $--color-very-light-blue;
   padding: 20px 8px;
   border-radius: 7px 0 0 7px;
   display: flex;


### PR DESCRIPTION
### Description of the Changes

Remove `border` CSS from `SideButton` component.

Solves #[3155991918](https://starkware.monday.com/boards/2847524005/pulses/3155991918)

---

### Checklist

- [x] Manually tests of the main Application flows are done and passed.
- [ ] New unit / functional tests have been added (whenever applicable).
- [ ] Docs have been updated (whenever relevant).
- [x] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/295)
<!-- Reviewable:end -->
