### PR TITLE
fix: Wallet L1 & L2 is connected auto connect

### DIFF
--- a/src/components/UI/EthereumWalletButton/EthereumWalletButton.js
+++ b/src/components/UI/EthereumWalletButton/EthereumWalletButton.js
@@ -1,14 +1,22 @@
 import {ChainInfo, NetworkType} from '@starkware-industries/commons-js-enums';
-
-import {useEnvs} from '../../../hooks';
+import {useEffect} from 'react';
+import {useEnvs, useEthereumAddress} from '../../../hooks';
 import {useIsL1} from '../../../providers/TransferProvider';
 import {useL1Wallet} from '../../../providers/WalletsProvider';
 import {NetworkWalletButton} from '../index';
+import Wallets from '../../../config/wallets.js';
 
 export const EthereumWalletButton = () => {
-  const {account, config, error, status} = useL1Wallet();
+  const {account, config, error, status, connectWallet} = useL1Wallet();
   const {SUPPORTED_L1_CHAIN_ID} = useEnvs();
   const [, swapToL1] = useIsL1();
+  const ethereumAddress = useEthereumAddress();
+
+  useEffect(() => {
+    if (ethereumAddress) {
+      connectWallet(Wallets.L1);
+    }
+  }, [ethereumAddress]);
 
   return (
     <NetworkWalletButton

--- a/src/components/UI/StarknetWalletButton/StarknetWalletButton.js
+++ b/src/components/UI/StarknetWalletButton/StarknetWalletButton.js
@@ -1,15 +1,27 @@
 import {ChainInfo, NetworkType} from '@starkware-industries/commons-js-enums';
-import React from 'react';
+import React, {useEffect} from 'react';
 
-import {useEnvs} from '../../../hooks';
+import {useEnvs, useStarknetAddress} from '../../../hooks';
 import {useIsL2} from '../../../providers/TransferProvider';
 import {useL2Wallet} from '../../../providers/WalletsProvider';
 import {NetworkWalletButton} from '../index';
+import Wallets from '../../../config/wallets.js';
 
 export const StarknetWalletButton = () => {
-  const {account, config, error, status} = useL2Wallet();
+  const {account, config, error, status, connectWallet} = useL2Wallet();
   const {SUPPORTED_L2_CHAIN_ID} = useEnvs();
   const [, swapToL2] = useIsL2();
+
+  const address = useStarknetAddress();
+
+  useEffect(() => {
+    if (address) {
+      connectWallet({
+        ...Wallets.L2,
+        starknetWalletOptions: {showList: false}
+      });
+    }
+  }, [address]);
 
   return (
     <NetworkWalletButton

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -20,3 +20,5 @@ export * from './useBridgeContractAPI';
 export * from './useTokenContractAPI';
 export * from './useFonts';
 export * from './useDidMountEffect';
+export * from './useEthereumAddress';
+export * from './useStarknetAddress';

--- a/src/hooks/useEthereumAddress.js
+++ b/src/hooks/useEthereumAddress.js
@@ -1,0 +1,3 @@
+import {useMemo} from 'react';
+
+export const useEthereumAddress = () => useMemo(() => window?.ethereum?.selectedAddress, []);

--- a/src/hooks/useStarknetAddress.js
+++ b/src/hooks/useStarknetAddress.js
@@ -1,0 +1,16 @@
+import {useEffect, useState} from 'react';
+import {getStarknet} from '@starkware-industries/commons-js-libs/get-starknet';
+
+export const useStarknetAddress = () => {
+    const [address, setAddress] = useState('');
+
+    useEffect(async () => {
+        const account = await getStarknet().enable({showModal: false});
+
+        if (account?.length) {
+            setAddress(account[0]);
+        }
+    }, []);
+
+    return address;
+};

--- a/src/providers/WalletsProvider/wallets-hooks.js
+++ b/src/providers/WalletsProvider/wallets-hooks.js
@@ -84,7 +84,8 @@ export const useStarknetWallet = () => {
       const wallet = await getStarknetWallet({
         modalOptions: {
           theme: 'dark'
-        }
+        },
+        ...walletConfig.starknetWalletOptions
       });
       if (!wallet) {
         return;


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

Solves #[INSERT_MONDAY_ID_HERE](INSERT_MONDAY_URL_HERE)

If the user is already connected to the wallet, it will be automatically connected when entering the page.Fewer clicks, better user experience.

origin:

[origin.webm](https://user-images.githubusercontent.com/53848281/201484540-cffad78c-770f-48d8-a2c0-1e7178c1eed4.webm)

change:

[change.webm](https://user-images.githubusercontent.com/53848281/201484558-ad0d3739-3908-4eb1-b93a-717c57e7f350.webm)


* walletConfig add 'starknetWalletOptions' props, change getStarknetWallet option

---

### Checklist

- [x] Manually tests of the main Application flows are done and passed.
- [ ] New unit / functional tests have been added (whenever applicable).
- [ ] Docs have been updated (whenever relevant).
- [x] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starkgate-frontend/324)
<!-- Reviewable:end -->
