### PR TITLE
feat: Select token supports uppercase search & Support symbol search

### DIFF
--- a/src/components/UI/SearchToken/SearchToken.js
+++ b/src/components/UI/SearchToken/SearchToken.js
@@ -16,7 +16,15 @@ export const SearchToken = ({tokens, onSearchResults}) => {
   };
 
   useEffect(() => {
-    const results = tokens.filter(token => token.name.toLowerCase().includes(searchTerm));
+    const results = tokens.filter(token => {
+      const {name, symbol} = token;
+      const searchTermValue = searchTerm.toLowerCase();
+
+      return (
+        name.toLowerCase().includes(searchTermValue) ||
+        symbol.toLowerCase().includes(searchTermValue)
+      );
+    });
     onSearchResults(results);
   }, [searchTerm]);
 


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

Solves #[INSERT_MONDAY_ID_HERE](INSERT_MONDAY_URL_HERE)

When entering 'ETH', 'usdc' in the search box, the correct results cannot be obtained. There is also a discussion about whether spaces should be included in the search. Referring to uniswap, both upper and lower case can be searched normally, spaces are not in the search field, and only symbols are retrieved.

change:

[Screencast from 27-11-22 09:37:54.webm](https://user-images.githubusercontent.com/53848281/204115411-2dddf7eb-b8b3-4352-819c-bbf0e7c686d8.webm)

origin:

[Screencast from 27-11-22 09:35:47.webm](https://user-images.githubusercontent.com/53848281/204115413-5d52e1c1-dd0d-47a5-a41d-918c7eb627cf.webm)

uniswap:


[Screencast from 27-11-22 09:38:21.webm](https://user-images.githubusercontent.com/53848281/204115416-ad0a3c7f-4e98-4e0c-ad4c-454164b28d11.webm)

---

### Checklist

- [ ] Manually tests of the main Application flows are done and passed.
- [ ] New unit / functional tests have been added (whenever applicable).
- [ ] Docs have been updated (whenever relevant).
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`
