### PR TITLE
feat: wallet extensions supports edge browser

### DIFF
--- a/src/wallets/wallet-handler.js
+++ b/src/wallets/wallet-handler.js
@@ -1,4 +1,9 @@
-import {getPropertyPath, isChrome, isFirefox} from '@starkware-industries/commons-js-utils';
+import {
+  getPropertyPath,
+  isChrome,
+  isFirefox,
+  getBrowserName
+} from '@starkware-industries/commons-js-utils';
 
 import strings from '../config/strings';
 
@@ -8,7 +13,9 @@ export class WalletHandler {
   }
 
   isBrowserSupported() {
-    const isBrowserSupported = isChrome() || isFirefox();
+    const isEdge = () => getBrowserName() === 'Edge';
+    const isBrowserSupported = isChrome() || isFirefox() || isEdge();
+
     if (!isBrowserSupported) {
       throw new Error(getPropertyPath(strings, 'modals.login.unsupportedBrowserTxt'));
     }


### PR DESCRIPTION
### Description of the Changes
Wallet connection supports edge browser.

This is the value of Desktop Browser Market Share worldwide OCT2021-OCT2022 [link](https://gs.statcounter.com/browser-market-share/desktop/worldwide/):

* Chrome 66.46%
* Edge 10.85%
* Safari 9.38%
* Firefox 7.05%

It can be seen that the share of Edge is still good. The native plug-in of Edge already supports Metamask, and Edge is fully compatible with other Chrome plug-ins, and can be used normally during the development process.

origin:
![image](https://user-images.githubusercontent.com/53848281/204118684-668e359e-3bb5-4587-b8be-61648720dcbf.png)

change:

Not Installed:
[change_not_installed.webm](https://user-images.githubusercontent.com/53848281/204118867-22781405-4ad4-4b01-87c6-ea62e913d1d8.webm)

Installed:
[change_installedwebm](https://user-images.githubusercontent.com/53848281/204118945-66acd922-94e5-4ec4-a929-9c81053a8ce3.webm)


---

### Checklist

- [ ] Manually tests of the main Application flows are done and passed.
- [ ] New unit / functional tests have been added (whenever applicable).
- [ ] Docs have been updated (whenever relevant).
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`
